### PR TITLE
feat: scaffold vector store service

### DIFF
--- a/openspec/changes/add-vector-storage-retrieval/tasks.md
+++ b/openspec/changes/add-vector-storage-retrieval/tasks.md
@@ -2,11 +2,11 @@
 
 ## 1. Core Interfaces & Models
 
-- [ ] 1.1 Define `VectorStorePort` protocol (create_or_update_collection, upsert, knn, delete)
-- [ ] 1.2 Create `IndexParams` model (kind, metric, dim, HNSW/IVF/DiskANN parameters)
-- [ ] 1.3 Create `CompressionPolicy` model (kind, pq_m, pq_nbits, opq_m)
-- [ ] 1.4 Implement namespace registry with dimension validation
-- [ ] 1.5 Create vector store factory with backend selection
+- [x] 1.1 Define `VectorStorePort` protocol (create_or_update_collection, upsert, knn, delete)
+- [x] 1.2 Create `IndexParams` model (kind, metric, dim, HNSW/IVF/DiskANN parameters)
+- [x] 1.3 Create `CompressionPolicy` model (kind, pq_m, pq_nbits, opq_m)
+- [x] 1.4 Implement namespace registry with dimension validation
+- [x] 1.5 Create vector store factory with backend selection
 
 ## 2. Dense Vector Store Adapters (Primary)
 

--- a/src/Medical_KG_rev/services/retrieval/retrieval_service.py
+++ b/src/Medical_KG_rev/services/retrieval/retrieval_service.py
@@ -2,12 +2,22 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
+
+import structlog
+
+from Medical_KG_rev.auth.context import SecurityContext
+from Medical_KG_rev.services.vector_store.errors import VectorStoreError
+from Medical_KG_rev.services.vector_store.models import VectorQuery
+from Medical_KG_rev.services.vector_store.service import VectorStoreService
 
 from .faiss_index import FAISSIndex
 from .opensearch_client import OpenSearchClient
 from .reranker import CrossEncoderReranker
+
+
+logger = structlog.get_logger(__name__)
 
 
 @dataclass(slots=True)
@@ -24,12 +34,19 @@ class RetrievalService:
     def __init__(
         self,
         opensearch: OpenSearchClient,
-        faiss: FAISSIndex,
+        faiss: FAISSIndex | None = None,
         reranker: CrossEncoderReranker | None = None,
+        *,
+        vector_store: VectorStoreService | None = None,
+        vector_namespace: str = "default",
+        context_factory: Callable[[], SecurityContext] | None = None,
     ) -> None:
         self.opensearch = opensearch
         self.faiss = faiss
         self.reranker = reranker or CrossEncoderReranker()
+        self.vector_store = vector_store
+        self.vector_namespace = vector_namespace
+        self._context_factory = context_factory
 
     def search(
         self,
@@ -38,22 +55,33 @@ class RetrievalService:
         filters: Mapping[str, object] | None = None,
         k: int = 10,
         rerank: bool = False,
+        *,
+        context: SecurityContext | None = None,
     ) -> list[RetrievalResult]:
+        security_context = context or (
+            self._context_factory()
+            if self._context_factory
+            else SecurityContext(subject="system", tenant_id="system", scopes={"*"})
+        )
         bm25_results = self.opensearch.search(
             index, query, strategy="bm25", filters=filters, size=k
         )
         splade_results = self.opensearch.search(
             index, query, strategy="splade", filters=filters, size=k
         )
-        dense_results = self._dense_search(query, k)
+        dense_results = self._dense_search(query, k, security_context)
         fused = self._fuse_results([bm25_results, splade_results, dense_results])
         if rerank:
             fused = self._apply_rerank(query, fused)
         fused.sort(key=lambda item: item.rerank_score or item.retrieval_score, reverse=True)
         return fused
 
-    def _dense_search(self, query: str, k: int) -> list[Mapping[str, object]]:
-        if not self.faiss.ids:
+    def _dense_search(
+        self, query: str, k: int, context: SecurityContext
+    ) -> list[Mapping[str, object]]:
+        if self.vector_store is not None:
+            return self._vector_store_search(query, k, context)
+        if not self.faiss or not self.faiss.ids:
             return []
         pseudo_query = [float(hash(token) % 100) for token in query.split()]
         if len(pseudo_query) < self.faiss.dimension:
@@ -68,6 +96,53 @@ class RetrievalService:
                     "_id": chunk_id,
                     "_score": score,
                     "_source": {"text": metadata.get("text", ""), **metadata},
+                    "highlight": [],
+                }
+            )
+        return results
+
+    def _vector_store_search(
+        self, query: str, k: int, context: SecurityContext
+    ) -> list[Mapping[str, object]]:
+        pseudo_query = [float(hash(token) % 100) for token in query.split()]
+        namespace = self.vector_namespace
+        try:
+            dimension = self.vector_store.registry.get(
+                tenant_id=context.tenant_id, namespace=namespace
+            ).params.dimension
+            if len(pseudo_query) < dimension:
+                pseudo_query.extend([0.0] * (dimension - len(pseudo_query)))
+            elif len(pseudo_query) > dimension:
+                pseudo_query = pseudo_query[:dimension]
+            matches = self.vector_store.query(
+                context=context,
+                namespace=namespace,
+                query=VectorQuery(values=pseudo_query, top_k=k),
+            )
+        except VectorStoreError as exc:
+            logger.warning(
+                "retrieval.vector_search.failed",
+                namespace=namespace,
+                error=str(exc),
+            )
+            return []
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning(
+                "retrieval.vector_search.failed",
+                namespace=namespace,
+                error=str(exc),
+            )
+            return []
+        results: list[Mapping[str, object]] = []
+        for match in matches:
+            results.append(
+                {
+                    "_id": match.vector_id,
+                    "_score": match.score,
+                    "_source": {
+                        "text": str(match.metadata.get("text", "")),
+                        **match.metadata,
+                    },
                     "highlight": [],
                 }
             )

--- a/src/Medical_KG_rev/services/vector_store/__init__.py
+++ b/src/Medical_KG_rev/services/vector_store/__init__.py
@@ -1,0 +1,49 @@
+"""Vector storage service abstractions and implementations."""
+
+from .errors import (
+    BackendUnavailableError,
+    DimensionMismatchError,
+    InvalidNamespaceConfigError,
+    NamespaceNotFoundError,
+    ResourceExhaustedError,
+    ScopeError,
+    VectorStoreError,
+)
+from .factory import VectorStoreFactory
+from .models import (
+    CompressionPolicy,
+    IndexParams,
+    NamespaceConfig,
+    UpsertResult,
+    VectorMatch,
+    VectorQuery,
+    VectorRecord,
+)
+from .registry import NamespaceRegistry
+from .service import VectorStoreService
+from .stores.faiss import FaissVectorStore
+from .stores.memory import InMemoryVectorStore
+from .types import VectorStorePort
+
+__all__ = [
+    "BackendUnavailableError",
+    "CompressionPolicy",
+    "DimensionMismatchError",
+    "InvalidNamespaceConfigError",
+    "FaissVectorStore",
+    "InMemoryVectorStore",
+    "IndexParams",
+    "NamespaceConfig",
+    "NamespaceNotFoundError",
+    "NamespaceRegistry",
+    "ResourceExhaustedError",
+    "ScopeError",
+    "UpsertResult",
+    "VectorMatch",
+    "VectorQuery",
+    "VectorRecord",
+    "VectorStoreError",
+    "VectorStoreFactory",
+    "VectorStorePort",
+    "VectorStoreService",
+]

--- a/src/Medical_KG_rev/services/vector_store/errors.py
+++ b/src/Medical_KG_rev/services/vector_store/errors.py
@@ -1,0 +1,76 @@
+"""Custom exceptions for the vector store subsystem."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from Medical_KG_rev.utils.errors import FoundationError
+
+
+class VectorStoreError(FoundationError):
+    """Base class for vector store errors with RFC 7807 payloads."""
+
+    def __init__(self, message: str, *, status: int, detail: str | None = None, extra: dict[str, Any] | None = None) -> None:
+        super().__init__(message, status=status, detail=detail)
+        if extra:
+            self.problem.extra = extra
+
+
+class NamespaceNotFoundError(VectorStoreError):
+    def __init__(self, namespace: str, *, tenant_id: str) -> None:
+        super().__init__(
+            "Vector namespace not found",
+            status=404,
+            detail=f"Namespace '{namespace}' is not registered for tenant '{tenant_id}'.",
+            extra={"namespace": namespace, "tenant_id": tenant_id},
+        )
+
+
+class DimensionMismatchError(VectorStoreError):
+    def __init__(self, expected: int, actual: int, *, namespace: str) -> None:
+        super().__init__(
+            "Vector dimension mismatch",
+            status=422,
+            detail=f"Expected dimension {expected}, received {actual}.",
+            extra={"expected": expected, "actual": actual, "namespace": namespace},
+        )
+
+
+class ResourceExhaustedError(VectorStoreError):
+    def __init__(self, namespace: str, *, detail: str | None = None) -> None:
+        super().__init__(
+            "Vector store capacity exceeded",
+            status=507,
+            detail=detail or "The vector backend cannot accept more data.",
+            extra={"namespace": namespace},
+        )
+
+
+class BackendUnavailableError(VectorStoreError):
+    def __init__(self, message: str = "Vector backend unavailable", *, retry_after: float | None = None) -> None:
+        super().__init__(
+            message,
+            status=503,
+            detail="Vector store backend is temporarily unavailable.",
+            extra={"retry_after": retry_after} if retry_after else None,
+        )
+
+
+class ScopeError(VectorStoreError):
+    def __init__(self, *, required_scope: str) -> None:
+        super().__init__(
+            "Missing required scope",
+            status=403,
+            detail=f"The caller lacks the '{required_scope}' scope.",
+            extra={"required_scope": required_scope},
+        )
+
+
+class InvalidNamespaceConfigError(VectorStoreError):
+    def __init__(self, namespace: str, *, detail: str) -> None:
+        super().__init__(
+            "Invalid namespace configuration",
+            status=422,
+            detail=detail,
+            extra={"namespace": namespace},
+        )

--- a/src/Medical_KG_rev/services/vector_store/factory.py
+++ b/src/Medical_KG_rev/services/vector_store/factory.py
@@ -1,0 +1,28 @@
+"""Factory helpers to construct vector store adapters from configuration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from .stores.faiss import FaissVectorStore
+from .stores.memory import InMemoryVectorStore
+from .types import VectorStorePort
+
+_SUPPORTED_DRIVERS = {
+    "memory": InMemoryVectorStore,
+    "faiss": FaissVectorStore,
+}
+
+
+class VectorStoreFactory:
+    """Factory that instantiates vector store adapters."""
+
+    def __init__(self, config: Mapping[str, object] | None = None) -> None:
+        self.config = config or {}
+
+    def build(self) -> VectorStorePort:
+        driver = str(self.config.get("driver", "memory")).lower()
+        if driver not in _SUPPORTED_DRIVERS:
+            raise ValueError(f"Unsupported vector store driver '{driver}'")
+        cls = _SUPPORTED_DRIVERS[driver]
+        return cls()

--- a/src/Medical_KG_rev/services/vector_store/models.py
+++ b/src/Medical_KG_rev/services/vector_store/models.py
@@ -1,0 +1,81 @@
+"""Domain models for the vector store subsystem."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+
+
+@dataclass(slots=True, frozen=True)
+class CompressionPolicy:
+    """Configuration describing how vectors are compressed in the store."""
+
+    kind: str = "none"
+    pq_m: int | None = None
+    pq_nbits: int | None = None
+    opq_m: int | None = None
+
+    def is_enabled(self) -> bool:
+        return self.kind != "none"
+
+
+@dataclass(slots=True, frozen=True)
+class IndexParams:
+    """Parameters describing a namespace/collection."""
+
+    dimension: int
+    metric: str = "cosine"
+    kind: str = "hnsw"
+    ef_search: int | None = None
+    ef_construct: int | None = None
+    m: int | None = None
+    nlist: int | None = None
+    nprobe: int | None = None
+    replicas: int | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class NamespaceConfig:
+    """Runtime configuration for a namespace."""
+
+    name: str
+    params: IndexParams
+    compression: CompressionPolicy = field(default_factory=CompressionPolicy)
+    version: str = "v1"
+
+
+@dataclass(slots=True, frozen=True)
+class VectorRecord:
+    """Represents a vector ready to be persisted."""
+
+    vector_id: str
+    values: Sequence[float]
+    metadata: Mapping[str, object] = field(default_factory=dict)
+    vector_version: str | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class VectorQuery:
+    """Query payload for vector similarity search."""
+
+    values: Sequence[float]
+    top_k: int = 10
+    filters: Mapping[str, object] | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class VectorMatch:
+    """Result from a vector similarity query."""
+
+    vector_id: str
+    score: float
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(slots=True, frozen=True)
+class UpsertResult:
+    """Summary returned after an upsert operation."""
+
+    namespace: str
+    upserted: int
+    version: str

--- a/src/Medical_KG_rev/services/vector_store/registry.py
+++ b/src/Medical_KG_rev/services/vector_store/registry.py
@@ -1,0 +1,57 @@
+"""Namespace registry for vector store collections."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from .errors import DimensionMismatchError, InvalidNamespaceConfigError, NamespaceNotFoundError
+from .models import NamespaceConfig
+
+
+@dataclass(slots=True)
+class NamespaceRegistry:
+    """In-memory registry of namespaces keyed by tenant."""
+
+    _namespaces: dict[str, dict[str, NamespaceConfig]]
+
+    def __init__(self) -> None:
+        self._namespaces = {}
+
+    def register(self, *, tenant_id: str, config: NamespaceConfig) -> None:
+        if not 128 <= config.params.dimension <= 4096:
+            raise InvalidNamespaceConfigError(
+                config.name,
+                detail="Vector dimension must be between 128 and 4096.",
+            )
+        tenant_namespaces = self._namespaces.setdefault(tenant_id, {})
+        existing = tenant_namespaces.get(config.name)
+        if existing and existing.params.dimension != config.params.dimension:
+            raise DimensionMismatchError(
+                existing.params.dimension,
+                config.params.dimension,
+                namespace=config.name,
+            )
+        tenant_namespaces[config.name] = config
+
+    def get(self, *, tenant_id: str, namespace: str) -> NamespaceConfig:
+        tenant_namespaces = self._namespaces.get(tenant_id)
+        if not tenant_namespaces or namespace not in tenant_namespaces:
+            raise NamespaceNotFoundError(namespace, tenant_id=tenant_id)
+        return tenant_namespaces[namespace]
+
+    def ensure_dimension(
+        self,
+        *,
+        tenant_id: str,
+        namespace: str,
+        vector_length: int,
+    ) -> None:
+        config = self.get(tenant_id=tenant_id, namespace=namespace)
+        if config.params.dimension != vector_length:
+            raise DimensionMismatchError(
+                config.params.dimension, vector_length, namespace=namespace
+            )
+
+    def list(self, *, tenant_id: str) -> Mapping[str, NamespaceConfig]:
+        return dict(self._namespaces.get(tenant_id, {}))

--- a/src/Medical_KG_rev/services/vector_store/service.py
+++ b/src/Medical_KG_rev/services/vector_store/service.py
@@ -1,0 +1,269 @@
+"""High-level service that orchestrates vector store operations."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterable, Mapping, Sequence
+
+import structlog
+
+from Medical_KG_rev.auth.audit import AuditTrail, get_audit_trail
+from Medical_KG_rev.auth.context import SecurityContext
+
+from .errors import (
+    BackendUnavailableError,
+    DimensionMismatchError,
+    NamespaceNotFoundError,
+    ResourceExhaustedError,
+    ScopeError,
+    VectorStoreError,
+)
+from .models import NamespaceConfig, UpsertResult, VectorMatch, VectorQuery, VectorRecord
+from .registry import NamespaceRegistry
+from .types import VectorStorePort
+
+logger = structlog.get_logger(__name__)
+
+
+class VectorStoreService:
+    """Coordinates namespace governance, security, and auditing for vector storage."""
+
+    def __init__(
+        self,
+        store: VectorStorePort,
+        registry: NamespaceRegistry,
+        *,
+        audit_trail: AuditTrail | None = None,
+        failure_threshold: int = 5,
+        recovery_window_seconds: float = 30.0,
+    ) -> None:
+        self.store = store
+        self.registry = registry
+        self.audit = audit_trail or get_audit_trail()
+        self.failure_threshold = failure_threshold
+        self.recovery_window_seconds = recovery_window_seconds
+        self._failure_count = 0
+        self._circuit_opened_at: float | None = None
+
+    # ------------------------------------------------------------------
+    # Namespace management
+    # ------------------------------------------------------------------
+    def ensure_namespace(
+        self,
+        *,
+        context: SecurityContext,
+        config: NamespaceConfig,
+        metadata: Mapping[str, object] | None = None,
+    ) -> None:
+        """Register namespace and propagate to the backing store."""
+
+        self._require_scope(context, "index:write")
+        logger.info(
+            "vector.namespace.ensure",
+            tenant_id=context.tenant_id,
+            namespace=config.name,
+            version=config.version,
+        )
+        self.registry.register(tenant_id=context.tenant_id, config=config)
+        self.store.create_or_update_collection(
+            tenant_id=context.tenant_id,
+            namespace=config.name,
+            params=config.params,
+            metadata={"version": config.version, **(metadata or {})},
+        )
+
+    # ------------------------------------------------------------------
+    # Vector operations
+    # ------------------------------------------------------------------
+    def upsert(
+        self,
+        *,
+        context: SecurityContext,
+        namespace: str,
+        records: Sequence[VectorRecord],
+    ) -> UpsertResult:
+        self._require_scope(context, "index:write")
+        if not records:
+            return UpsertResult(namespace=namespace, upserted=0, version="")
+        namespace_config = self.registry.get(
+            tenant_id=context.tenant_id, namespace=namespace
+        )
+        for record in records:
+            self._validate_dimension(namespace_config, len(record.values))
+        start = time.perf_counter()
+        try:
+            self._guard_circuit_breaker()
+            self.store.upsert(
+                tenant_id=context.tenant_id,
+                namespace=namespace,
+                records=records,
+            )
+        except VectorStoreError as error:
+            self._record_failure(error)
+            raise
+        else:
+            self._reset_failures()
+        duration = time.perf_counter() - start
+        self.audit.record(
+            context=context,
+            action="vector.upsert",
+            resource=namespace,
+            metadata={
+                "count": len(records),
+                "duration_ms": round(duration * 1000, 3),
+                "version": namespace_config.version,
+            },
+        )
+        logger.info(
+            "vector.upsert",
+            tenant_id=context.tenant_id,
+            namespace=namespace,
+            count=len(records),
+            duration_ms=duration * 1000,
+        )
+        return UpsertResult(
+            namespace=namespace,
+            upserted=len(records),
+            version=namespace_config.version,
+        )
+
+    def query(
+        self,
+        *,
+        context: SecurityContext,
+        namespace: str,
+        query: VectorQuery,
+    ) -> Sequence[VectorMatch]:
+        self._require_scope(context, "index:read")
+        self.registry.ensure_dimension(
+            tenant_id=context.tenant_id,
+            namespace=namespace,
+            vector_length=len(query.values),
+        )
+        start = time.perf_counter()
+        try:
+            self._guard_circuit_breaker()
+            matches = list(
+                self.store.query(
+                    tenant_id=context.tenant_id,
+                    namespace=namespace,
+                    query=query,
+                )
+            )
+        except VectorStoreError as error:
+            self._record_failure(error)
+            raise
+        else:
+            self._reset_failures()
+        duration = time.perf_counter() - start
+        self.audit.record(
+            context=context,
+            action="vector.query",
+            resource=namespace,
+            metadata={
+                "top_k": query.top_k,
+                "duration_ms": round(duration * 1000, 3),
+                "returned": len(matches),
+            },
+        )
+        logger.info(
+            "vector.query",
+            tenant_id=context.tenant_id,
+            namespace=namespace,
+            top_k=query.top_k,
+            returned=len(matches),
+            duration_ms=duration * 1000,
+        )
+        return matches
+
+    def delete(
+        self,
+        *,
+        context: SecurityContext,
+        namespace: str,
+        vector_ids: Sequence[str],
+    ) -> int:
+        self._require_scope(context, "index:write")
+        self.registry.get(tenant_id=context.tenant_id, namespace=namespace)
+        try:
+            self._guard_circuit_breaker()
+            removed = self.store.delete(
+                tenant_id=context.tenant_id,
+                namespace=namespace,
+                vector_ids=vector_ids,
+            )
+        except VectorStoreError as error:
+            self._record_failure(error)
+            raise
+        else:
+            self._reset_failures()
+        logger.info(
+            "vector.delete",
+            tenant_id=context.tenant_id,
+            namespace=namespace,
+            removed=removed,
+        )
+        if removed:
+            self.audit.record(
+                context=context,
+                action="vector.delete",
+                resource=namespace,
+                metadata={"removed": removed},
+            )
+        return removed
+
+    # ------------------------------------------------------------------
+    # Helper utilities
+    # ------------------------------------------------------------------
+    def _validate_dimension(self, config: NamespaceConfig, dimension: int) -> None:
+        if config.params.dimension != dimension:
+            raise DimensionMismatchError(
+                config.params.dimension, dimension, namespace=config.name
+            )
+
+    def _require_scope(self, context: SecurityContext, scope: str) -> None:
+        if not context.has_scope(scope):
+            raise ScopeError(required_scope=scope)
+
+    def _guard_circuit_breaker(self) -> None:
+        if self._circuit_opened_at is None:
+            return
+        elapsed = time.perf_counter() - self._circuit_opened_at
+        if elapsed < self.recovery_window_seconds:
+            raise BackendUnavailableError(
+                "Vector store circuit breaker open", retry_after=self.recovery_window_seconds - elapsed
+            )
+        self._circuit_opened_at = None
+        self._failure_count = 0
+
+    def _record_failure(self, error: VectorStoreError) -> None:
+        logger.warning("vector.store.failure", error=error, error_type=type(error).__name__)
+        if isinstance(error, BackendUnavailableError):
+            self._failure_count += 1
+            if self._failure_count >= self.failure_threshold:
+                self._circuit_opened_at = time.perf_counter()
+        elif isinstance(error, ResourceExhaustedError):
+            # Resource exhaustion is terminal for the request; reset failures so breaker stays closed
+            self._reset_failures()
+        else:
+            self._failure_count += 1
+
+    def _reset_failures(self) -> None:
+        self._failure_count = 0
+        self._circuit_opened_at = None
+
+    def bulk_upsert(
+        self,
+        *,
+        context: SecurityContext,
+        namespace: str,
+        batches: Iterable[Sequence[VectorRecord]],
+    ) -> UpsertResult:
+        total = 0
+        for batch in batches:
+            result = self.upsert(context=context, namespace=namespace, records=batch)
+            total += result.upserted
+        version = self.registry.get(
+            tenant_id=context.tenant_id, namespace=namespace
+        ).version
+        return UpsertResult(namespace=namespace, upserted=total, version=version)

--- a/src/Medical_KG_rev/services/vector_store/stores/faiss.py
+++ b/src/Medical_KG_rev/services/vector_store/stores/faiss.py
@@ -1,0 +1,102 @@
+"""Adapter that wraps the lightweight FAISSIndex used in tests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from Medical_KG_rev.services.retrieval.faiss_index import FAISSIndex
+
+from ..errors import DimensionMismatchError, NamespaceNotFoundError
+from ..models import IndexParams, VectorMatch, VectorQuery, VectorRecord
+from ..types import VectorStorePort
+
+
+@dataclass(slots=True)
+class _TenantNamespace:
+    index: FAISSIndex
+
+
+class FaissVectorStore(VectorStorePort):
+    """Wraps FAISSIndex to conform to :class:`VectorStorePort`."""
+
+    def __init__(self) -> None:
+        self._state: dict[str, dict[str, _TenantNamespace]] = {}
+
+    def create_or_update_collection(
+        self,
+        *,
+        tenant_id: str,
+        namespace: str,
+        params: IndexParams,
+        metadata: Mapping[str, object] | None = None,
+    ) -> None:
+        tenant_state = self._state.setdefault(tenant_id, {})
+        existing = tenant_state.get(namespace)
+        if existing and existing.index.dimension != params.dimension:
+            raise DimensionMismatchError(
+                existing.index.dimension, params.dimension, namespace=namespace
+            )
+        if existing:
+            return
+        tenant_state[namespace] = _TenantNamespace(index=FAISSIndex(dimension=params.dimension))
+
+    def list_collections(self, *, tenant_id: str) -> Sequence[str]:
+        return list(self._state.get(tenant_id, {}).keys())
+
+    def upsert(
+        self,
+        *,
+        tenant_id: str,
+        namespace: str,
+        records: Sequence[VectorRecord],
+    ) -> None:
+        tenant_state = self._state.get(tenant_id, {})
+        state = tenant_state.get(namespace)
+        if not state:
+            raise NamespaceNotFoundError(namespace, tenant_id=tenant_id)
+        for record in records:
+            state.index.add(record.vector_id, record.values, record.metadata)
+
+    def query(
+        self,
+        *,
+        tenant_id: str,
+        namespace: str,
+        query: VectorQuery,
+    ) -> Sequence[VectorMatch]:
+        tenant_state = self._state.get(tenant_id, {})
+        state = tenant_state.get(namespace)
+        if not state:
+            return []
+        matches = state.index.search(query.values, k=query.top_k)
+        return [VectorMatch(vector_id=vector_id, score=score, metadata=metadata) for vector_id, score, metadata in matches]
+
+    def delete(
+        self,
+        *,
+        tenant_id: str,
+        namespace: str,
+        vector_ids: Sequence[str],
+    ) -> int:
+        tenant_state = self._state.get(tenant_id, {})
+        state = tenant_state.get(namespace)
+        if not state:
+            return 0
+        removed = 0
+        remaining_vectors = []
+        remaining_ids = []
+        remaining_metadata = []
+        for vector_id, vector, metadata in zip(
+            state.index.ids, state.index.vectors, state.index.metadata, strict=False
+        ):
+            if vector_id in vector_ids:
+                removed += 1
+                continue
+            remaining_ids.append(vector_id)
+            remaining_vectors.append(vector)
+            remaining_metadata.append(metadata)
+        state.index.ids = remaining_ids
+        state.index.vectors = remaining_vectors
+        state.index.metadata = remaining_metadata
+        return removed

--- a/src/Medical_KG_rev/services/vector_store/stores/memory.py
+++ b/src/Medical_KG_rev/services/vector_store/stores/memory.py
@@ -1,0 +1,127 @@
+"""In-memory vector store implementation for testing purposes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Final
+
+import numpy as np
+
+from ..errors import DimensionMismatchError, NamespaceNotFoundError, ResourceExhaustedError
+from ..models import IndexParams, VectorMatch, VectorQuery, VectorRecord
+from ..types import VectorStorePort
+
+_MAX_VECTORS_PER_NAMESPACE: Final[int] = 50_000
+
+
+@dataclass(slots=True)
+class _NamespaceState:
+    params: IndexParams
+    vectors: dict[str, np.ndarray] = field(default_factory=dict)
+    metadata: dict[str, Mapping[str, object]] = field(default_factory=dict)
+
+
+class InMemoryVectorStore(VectorStorePort):
+    """Simple numpy-backed store enforcing per-tenant isolation."""
+
+    def __init__(self) -> None:
+        self._state: dict[str, dict[str, _NamespaceState]] = {}
+
+    def create_or_update_collection(
+        self,
+        *,
+        tenant_id: str,
+        namespace: str,
+        params: IndexParams,
+        metadata: Mapping[str, object] | None = None,
+    ) -> None:
+        tenant_state = self._state.setdefault(tenant_id, {})
+        existing = tenant_state.get(namespace)
+        if existing:
+            if existing.params.dimension != params.dimension:
+                raise DimensionMismatchError(
+                    existing.params.dimension, params.dimension, namespace=namespace
+                )
+            return
+        tenant_state[namespace] = _NamespaceState(params=params)
+        if metadata:
+            tenant_state[namespace].metadata["__collection__"] = dict(metadata)
+
+    def list_collections(self, *, tenant_id: str) -> Sequence[str]:
+        return list(self._state.get(tenant_id, {}).keys())
+
+    def upsert(
+        self,
+        *,
+        tenant_id: str,
+        namespace: str,
+        records: Sequence[VectorRecord],
+    ) -> None:
+        tenant_state = self._state.setdefault(tenant_id, {})
+        state = tenant_state.get(namespace)
+        if not state:
+            raise NamespaceNotFoundError(namespace, tenant_id=tenant_id)
+        if len(state.vectors) + len(records) > _MAX_VECTORS_PER_NAMESPACE:
+            raise ResourceExhaustedError(namespace)
+        for record in records:
+            array = np.asarray(record.values, dtype=float)
+            if array.shape != (state.params.dimension,):
+                raise DimensionMismatchError(
+                    state.params.dimension, array.shape[0], namespace=namespace
+                )
+            state.vectors[record.vector_id] = array
+            state.metadata[record.vector_id] = dict(record.metadata)
+
+    def query(
+        self,
+        *,
+        tenant_id: str,
+        namespace: str,
+        query: VectorQuery,
+    ) -> Sequence[VectorMatch]:
+        tenant_state = self._state.get(tenant_id, {})
+        state = tenant_state.get(namespace)
+        if not state:
+            return []
+        query_vector = np.asarray(query.values, dtype=float)
+        if query_vector.shape != (state.params.dimension,):
+            raise DimensionMismatchError(
+                state.params.dimension, query_vector.shape[0], namespace=namespace
+            )
+        if not state.vectors:
+            return []
+        matrix = np.stack(list(state.vectors.values()))
+        scores = matrix @ query_vector
+        vector_ids = list(state.vectors.keys())
+        ranked = np.argsort(scores)[::-1][: query.top_k]
+        results: list[VectorMatch] = []
+        for idx in ranked:
+            vector_id = vector_ids[idx]
+            results.append(
+                VectorMatch(
+                    vector_id=vector_id,
+                    score=float(scores[idx]),
+                    metadata=state.metadata.get(vector_id, {}),
+                )
+            )
+        return results
+
+    def delete(
+        self,
+        *,
+        tenant_id: str,
+        namespace: str,
+        vector_ids: Sequence[str],
+    ) -> int:
+        tenant_state = self._state.get(tenant_id, {})
+        state = tenant_state.get(namespace)
+        if not state:
+            return 0
+        removed = 0
+        for vector_id in vector_ids:
+            if vector_id in state.vectors:
+                state.vectors.pop(vector_id, None)
+                state.metadata.pop(vector_id, None)
+                removed += 1
+        return removed

--- a/src/Medical_KG_rev/services/vector_store/types.py
+++ b/src/Medical_KG_rev/services/vector_store/types.py
@@ -1,0 +1,52 @@
+"""Protocol definitions for vector store adapters."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Protocol
+
+from .models import IndexParams, VectorMatch, VectorQuery, VectorRecord
+
+
+class VectorStorePort(Protocol):
+    """Protocol all vector store adapters must implement."""
+
+    def create_or_update_collection(
+        self,
+        *,
+        tenant_id: str,
+        namespace: str,
+        params: IndexParams,
+        metadata: Mapping[str, object] | None = None,
+    ) -> None:
+        """Ensure the target namespace exists with the provided parameters."""
+
+    def list_collections(self, *, tenant_id: str) -> Sequence[str]:
+        """Return namespaces available for the tenant."""
+
+    def upsert(
+        self,
+        *,
+        tenant_id: str,
+        namespace: str,
+        records: Sequence[VectorRecord],
+    ) -> None:
+        """Insert or update the supplied vector records."""
+
+    def query(
+        self,
+        *,
+        tenant_id: str,
+        namespace: str,
+        query: VectorQuery,
+    ) -> Sequence[VectorMatch]:
+        """Execute a vector similarity query."""
+
+    def delete(
+        self,
+        *,
+        tenant_id: str,
+        namespace: str,
+        vector_ids: Sequence[str],
+    ) -> int:
+        """Delete the specified vector identifiers and return the removed count."""

--- a/tests/services/vector_store/test_vector_store_service.py
+++ b/tests/services/vector_store/test_vector_store_service.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+
+from Medical_KG_rev.auth.context import SecurityContext
+from Medical_KG_rev.services.vector_store import (
+    CompressionPolicy,
+    DimensionMismatchError,
+    IndexParams,
+    NamespaceConfig,
+    NamespaceRegistry,
+    ScopeError,
+    VectorQuery,
+    VectorRecord,
+    VectorStoreService,
+)
+from Medical_KG_rev.services.vector_store.stores.memory import InMemoryVectorStore
+
+
+@pytest.fixture()
+def service() -> VectorStoreService:
+    registry = NamespaceRegistry()
+    store = InMemoryVectorStore()
+    svc = VectorStoreService(store, registry)
+    context = SecurityContext(subject="tester", tenant_id="tenant-a", scopes={"index:write", "index:read"})
+    config = NamespaceConfig(
+        name="dense.test.128.v1",
+        params=IndexParams(dimension=128, kind="hnsw"),
+        compression=CompressionPolicy(kind="none"),
+        version="v1",
+    )
+    svc.ensure_namespace(context=context, config=config)
+    return svc
+
+
+@pytest.fixture()
+def context() -> SecurityContext:
+    return SecurityContext(subject="tester", tenant_id="tenant-a", scopes={"index:write", "index:read"})
+
+
+def test_upsert_and_query_returns_results(service: VectorStoreService, context: SecurityContext) -> None:
+    base = [0.0] * 128
+    vec1 = base.copy()
+    vec1[0] = 1.0
+    vec2 = base.copy()
+    vec2[1] = 1.0
+    records = [
+        VectorRecord(vector_id="vec-1", values=vec1, metadata={"text": "alpha"}),
+        VectorRecord(vector_id="vec-2", values=vec2, metadata={"text": "beta"}),
+    ]
+    service.upsert(context=context, namespace="dense.test.128.v1", records=records)
+
+    matches = service.query(
+        context=context,
+        namespace="dense.test.128.v1",
+        query=VectorQuery(values=[1.0] + [0.0] * 127, top_k=2),
+    )
+
+    assert len(matches) == 2
+    assert matches[0].metadata["text"] == "alpha"
+
+
+def test_dimension_mismatch_raises(service: VectorStoreService, context: SecurityContext) -> None:
+    records = [VectorRecord(vector_id="vec-1", values=[1.0, 0.0], metadata={})]
+    with pytest.raises(DimensionMismatchError):
+        service.upsert(context=context, namespace="dense.test.128.v1", records=records)
+
+
+def test_scope_enforced(service: VectorStoreService, context: SecurityContext) -> None:
+    no_scope = SecurityContext(subject="tester", tenant_id="tenant-a", scopes={"index:read"})
+    records = [VectorRecord(vector_id="vec-1", values=[1.0] + [0.0] * 127, metadata={})]
+    with pytest.raises(ScopeError):
+        service.upsert(context=no_scope, namespace="dense.test.128.v1", records=records)


### PR DESCRIPTION
## Summary
- add a vector store subsystem with protocols, models, registry, and adapters for in-memory and FAISS backends
- introduce a managed VectorStoreService that enforces security scopes, auditing, and circuit breaking for vector operations
- integrate the retrieval service with the vector store and add unit tests covering the new service

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e4e10e219c832f93090fd8c8f72b5c