### PR TITLE
Implement add-embeddings-representation change

### DIFF
--- a/config/embeddings.yaml
+++ b/config/embeddings.yaml
@@ -1,34 +1,37 @@
 active_namespaces:
-  - single_vector.bge_small_en.384.v1
+  - single_vector.qwen3.4096.v1
   - sparse.splade_v3.400.v1
   - multi_vector.colbert_v2.128.v1
 
 namespaces:
-  single_vector.bge_small_en.384.v1:
-    name: bge-small-en
-    provider: sentence-transformers
+  single_vector.qwen3.4096.v1:
+    name: qwen3-embedding
+    provider: vllm
     kind: single_vector
-    model_id: BAAI/bge-small-en
-    model_version: v1.5
-    dim: 384
+    model_id: Qwen/Qwen2.5-Embedding-8B-Instruct
+    model_version: v1
+    dim: 4096
     pooling: mean
     normalize: true
-    batch_size: 32
-    prefixes:
-      query: "query:"
-      document: "passage:"
-    parameters: {}
+    batch_size: 64
+    requires_gpu: true
+    parameters:
+      endpoint: http://vllm-embeddings:8001/v1
+      timeout: 60
+      max_tokens: 8192
   sparse.splade_v3.400.v1:
     name: splade-v3
-    provider: splade-doc
+    provider: pyserini
     kind: sparse
-    model_id: splade-v3
+    model_id: naver/splade-v3
     model_version: v3
     dim: 400
     normalize: false
-    batch_size: 8
+    batch_size: 32
     parameters:
       top_k: 400
+      mode: document
+      max_terms: 400
   multi_vector.colbert_v2.128.v1:
     name: colbert-v2
     provider: colbert

--- a/openspec/changes/add-embeddings-representation/tasks.md
+++ b/openspec/changes/add-embeddings-representation/tasks.md
@@ -118,7 +118,7 @@
 
 **Goal**: Prove Pyserini SPLADE wrapper replaces all `SPLADEEmbedder` functionality
 
-- [ ] **1.2.2a** Map `SPLADEEmbedder` methods to Pyserini:
+- [x] **1.2.2a** Map `SPLADEEmbedder` methods to Pyserini:
   - `expand_document(text: str) -> dict[str, float]` → `pyserini.encode.SpladeQueryEncoder().encode(text)`
   - `expand_query(text: str) -> dict[str, float]` → Same method, different usage
   - Top-K pruning → Pyserini handles via `k` parameter
@@ -139,7 +139,7 @@
 
 **Goal**: Prove model-aligned tokenizers replace `token_counter.py`
 
-- [ ] **1.2.3a** Map token counting logic:
+- [x] **1.2.3a** Map token counting logic:
   - Approximate counting (`len(text) / 4`) → DELETED (inaccurate)
   - `transformers.AutoTokenizer.from_pretrained("Qwen/Qwen2.5-Coder-1.5B")` → NEW standard
 
@@ -160,7 +160,7 @@
   - vLLM queues requests exceeding batch size
   - vLLM returns results in same order as inputs
 
-- [ ] **1.2.4b** Remove custom batching logic:
+- [x] **1.2.4b** Remove custom batching logic:
   - `manual_batching.py` → DELETED (95 lines)
   - All batching handled by vLLM server
 

--- a/src/Medical_KG_rev/embeddings/dense/openai_compat.py
+++ b/src/Medical_KG_rev/embeddings/dense/openai_compat.py
@@ -1,19 +1,27 @@
-"""OpenAI compatible embedding endpoint adapter (vLLM / custom services)."""
+"""OpenAI-compatible embedding adapter used for vLLM-backed services."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Iterable
 
 import httpx
+
+from Medical_KG_rev.services import GpuNotAvailableError
 
 from ..ports import EmbedderConfig, EmbeddingRecord, EmbeddingRequest
 from ..registry import EmbedderRegistry
 from ..utils.normalization import normalize_batch
 
 
+class _HttpError(RuntimeError):
+    """Internal error used to unify HTTP error handling."""
+
+
 @dataclass(slots=True)
 class OpenAICompatEmbedder:
+    """Delegate embeddings to an OpenAI-compatible `/v1/embeddings` endpoint."""
+
     config: EmbedderConfig
     _endpoint: str = ""
     _timeout: float = 60.0
@@ -24,15 +32,21 @@ class OpenAICompatEmbedder:
 
     def __post_init__(self) -> None:
         params = self.config.parameters
-        if "endpoint" not in params:
+        endpoint = params.get("endpoint")
+        if not endpoint:
             raise ValueError("OpenAI compatible embedder requires 'endpoint' parameter")
-        self._endpoint = str(params["endpoint"]).rstrip("/")
+        # The config provides the `/v1` prefix so that requests map to the
+        # OpenAI API specification exactly.
+        self._endpoint = str(endpoint).rstrip("/")
         self._timeout = float(params.get("timeout", 60))
         self._api_key = params.get("api_key")
         self._normalize = bool(self.config.normalize)
         self.name = self.config.name
         self.kind = self.config.kind
 
+    # ------------------------------------------------------------------
+    # HTTP helpers
+    # ------------------------------------------------------------------
     def _headers(self) -> dict[str, str]:
         headers = {"Content-Type": "application/json"}
         if self._api_key:
@@ -44,25 +58,47 @@ class OpenAICompatEmbedder:
             "input": texts,
             "model": self.config.model_id,
         }
-        response = httpx.post(
-            f"{self._endpoint}/embeddings",
-            json=payload,
-            headers=self._headers(),
-            timeout=self._timeout,
-        )
-        response.raise_for_status()
+        try:
+            response = httpx.post(
+                f"{self._endpoint}/embeddings",
+                json=payload,
+                headers=self._headers(),
+                timeout=self._timeout,
+            )
+        except httpx.HTTPError as exc:  # pragma: no cover - network failure
+            raise _HttpError(f"Failed to call embeddings endpoint: {exc}") from exc
+        if response.status_code == 503:
+            detail = "GPU unavailable"
+            try:
+                error_payload = response.json()
+                detail = error_payload.get("error", {}).get("message", detail)
+            except Exception:  # pragma: no cover - defensive
+                detail = "GPU unavailable"
+            raise GpuNotAvailableError(detail)
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - propagate with context
+            raise _HttpError(str(exc)) from exc
         data = response.json()
         embeddings = [item["embedding"] for item in data.get("data", [])]
         if not embeddings:
             raise ValueError("OpenAI compatible endpoint returned no embeddings")
         return [list(map(float, vector)) for vector in embeddings]
 
-    def _records(self, request: EmbeddingRequest, vectors: list[list[float]]) -> list[EmbeddingRecord]:
+    # ------------------------------------------------------------------
+    # Record helpers
+    # ------------------------------------------------------------------
+    def _records(
+        self,
+        request: EmbeddingRequest,
+        vectors: Iterable[Iterable[float]],
+    ) -> list[EmbeddingRecord]:
+        converted = [list(map(float, vector)) for vector in vectors]
         if self._normalize:
-            vectors = normalize_batch(vectors)
-        ids = list(request.ids or [f"{request.namespace}:{index}" for index in range(len(vectors))])
+            converted = normalize_batch(converted)
+        ids = list(request.ids or [f"{request.namespace}:{index}" for index in range(len(converted))])
         records: list[EmbeddingRecord] = []
-        for chunk_id, vector in zip(ids, vectors, strict=False):
+        for chunk_id, vector in zip(ids, converted, strict=False):
             records.append(
                 EmbeddingRecord(
                     id=chunk_id,
@@ -80,6 +116,9 @@ class OpenAICompatEmbedder:
             )
         return records
 
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
     def embed_documents(self, request: EmbeddingRequest) -> list[EmbeddingRecord]:
         return self._records(request, self._request(list(request.texts)))
 
@@ -88,4 +127,6 @@ class OpenAICompatEmbedder:
 
 
 def register_openai_compat(registry: EmbedderRegistry) -> None:
-    registry.register("openai-compat", lambda config: OpenAICompatEmbedder(config=config))
+    factory = lambda config: OpenAICompatEmbedder(config=config)
+    registry.register("openai-compat", factory)
+    registry.register("vllm", factory)

--- a/src/Medical_KG_rev/embeddings/storage.py
+++ b/src/Medical_KG_rev/embeddings/storage.py
@@ -21,9 +21,9 @@ class StorageRouter:
 
     def __init__(self) -> None:
         self._targets: dict[EmbeddingKind, StorageTarget] = {
-            "single_vector": StorageTarget(name="qdrant", description="Dense vector store"),
+            "single_vector": StorageTarget(name="faiss", description="Dense vector store (HNSW)"),
             "multi_vector": StorageTarget(name="faiss", description="Late interaction index"),
-            "sparse": StorageTarget(name="opensearch", description="Learned sparse rank_features"),
+            "sparse": StorageTarget(name="opensearch_rank_features", description="Learned sparse rank_features"),
             "neural_sparse": StorageTarget(name="opensearch_neural", description="OpenSearch neural fields"),
         }
         self._buffers: dict[str, list[EmbeddingRecord]] = defaultdict(list)

--- a/src/Medical_KG_rev/embeddings/utils/gpu.py
+++ b/src/Medical_KG_rev/embeddings/utils/gpu.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 
 import structlog
 
+from Medical_KG_rev.services import GpuNotAvailableError
+
 logger = structlog.get_logger(__name__)
 
 
@@ -37,7 +39,9 @@ def ensure_available(require_gpu: bool, *, operation: str) -> None:
     status = probe()
     if not status.available:
         logger.error("embedding.gpu.missing", operation=operation)
-        raise RuntimeError(f"GPU is required for {operation} but no CUDA device is available")
+        raise GpuNotAvailableError(
+            f"GPU is required for {operation} but no CUDA device is available"
+        )
     logger.debug(
         "embedding.gpu.available",
         operation=operation,

--- a/src/Medical_KG_rev/embeddings/utils/tokenization.py
+++ b/src/Medical_KG_rev/embeddings/utils/tokenization.py
@@ -1,0 +1,91 @@
+"""Tokenization utilities aligned with embedding model vocabularies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Sequence
+
+import structlog
+
+
+logger = structlog.get_logger(__name__)
+
+
+class TokenizerUnavailableError(RuntimeError):
+    """Raised when a requested tokenizer cannot be loaded."""
+
+
+class TokenLimitExceededError(RuntimeError):
+    """Raised when a text exceeds the configured token budget."""
+
+
+@dataclass(slots=True)
+class _TokenizerWrapper:
+    """Lazy loader for HuggingFace tokenizers with caching."""
+
+    model_id: str
+    _tokenizer: object | None = None
+
+    def _load(self) -> object:
+        if self._tokenizer is None:
+            try:
+                from transformers import AutoTokenizer  # type: ignore import-not-found
+            except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+                raise TokenizerUnavailableError(
+                    "transformers is required for tokenizer-backed token counting"
+                ) from exc
+            logger.info("embedding.tokenizer.load", model=self.model_id)
+            self._tokenizer = AutoTokenizer.from_pretrained(self.model_id)
+        return self._tokenizer
+
+    def count(self, text: str) -> int:
+        tokenizer = self._load()
+        encode = getattr(tokenizer, "encode")
+        tokens = encode(text, add_special_tokens=False)
+        return len(tokens)
+
+
+@dataclass(slots=True)
+class TokenizerCache:
+    """Caches tokenizers per model id and validates token budgets."""
+
+    _tokenizers: dict[str, _TokenizerWrapper] = field(default_factory=dict)
+
+    def ensure_within_limit(
+        self,
+        *,
+        model_id: str,
+        texts: Sequence[str],
+        max_tokens: int | None,
+        correlation_id: str | None = None,
+    ) -> None:
+        if max_tokens is None:
+            return
+        wrapper = self._tokenizers.setdefault(model_id, _TokenizerWrapper(model_id))
+        for index, text in enumerate(texts):
+            token_count = wrapper.count(text)
+            if token_count > max_tokens:
+                logger.error(
+                    "embedding.tokenizer.limit_exceeded",
+                    model=model_id,
+                    tokens=token_count,
+                    max_tokens=max_tokens,
+                    correlation_id=correlation_id,
+                    chunk_index=index,
+                )
+                raise TokenLimitExceededError(
+                    f"Text has {token_count} tokens, max {max_tokens} for model {model_id}"
+                )
+        logger.debug(
+            "embedding.tokenizer.verified",
+            model=model_id,
+            max_tokens=max_tokens,
+            chunks=len(texts),
+        )
+
+
+__all__ = [
+    "TokenizerCache",
+    "TokenizerUnavailableError",
+    "TokenLimitExceededError",
+]

--- a/src/Medical_KG_rev/services/embedding/registry.py
+++ b/src/Medical_KG_rev/services/embedding/registry.py
@@ -24,27 +24,37 @@ logger = structlog.get_logger(__name__)
 
 
 _DEFAULT_NAMESPACES: dict[str, NamespaceDefinition] = {
-    "single_vector.bge_small_en.384.v1": NamespaceDefinition(
-        name="bge-small-en",
-        provider="sentence-transformers",
+    "single_vector.qwen3.4096.v1": NamespaceDefinition(
+        name="qwen3-embedding",
+        provider="vllm",
         kind="single_vector",
-        model_id="BAAI/bge-small-en",
-        model_version="v1.5",
-        dim=384,
+        model_id="Qwen/Qwen2.5-Embedding-8B-Instruct",
+        model_version="v1",
+        dim=4096,
         pooling="mean",
         normalize=True,
-        batch_size=32,
+        batch_size=64,
+        requires_gpu=True,
+        parameters={
+            "endpoint": "http://vllm-embeddings:8001/v1",
+            "timeout": 60,
+            "max_tokens": 8192,
+        },
     ),
     "sparse.splade_v3.400.v1": NamespaceDefinition(
         name="splade-v3",
-        provider="splade-doc",
+        provider="pyserini",
         kind="sparse",
-        model_id="splade-v3",
+        model_id="naver/splade-v3",
         model_version="v3",
         dim=400,
         normalize=False,
-        batch_size=8,
-        parameters={"top_k": 400},
+        batch_size=32,
+        parameters={
+            "top_k": 400,
+            "mode": "document",
+            "max_terms": 400,
+        },
     ),
     "multi_vector.colbert_v2.128.v1": NamespaceDefinition(
         name="colbert-v2",

--- a/src/Medical_KG_rev/services/embedding/service.py
+++ b/src/Medical_KG_rev/services/embedding/service.py
@@ -1,12 +1,12 @@
-"""Universal embedding service coordinating multiple adapters."""
+"""Embedding service orchestrating namespace-aware embedding adapters."""
 
 from __future__ import annotations
 
-import time
 from dataclasses import dataclass, field
-from typing import Sequence
+from typing import Mapping, Sequence
 
 import structlog
+
 from Medical_KG_rev.auth.context import SecurityContext
 from Medical_KG_rev.embeddings.namespace import NamespaceManager
 from Medical_KG_rev.embeddings.ports import (
@@ -16,7 +16,13 @@ from Medical_KG_rev.embeddings.ports import (
 from Medical_KG_rev.embeddings.ports import (
     EmbeddingRequest as AdapterEmbeddingRequest,
 )
+from Medical_KG_rev.embeddings.registry import EmbedderFactory, EmbedderRegistry
+from Medical_KG_rev.embeddings.storage import StorageRouter
 from Medical_KG_rev.embeddings.utils.gpu import ensure_available
+from Medical_KG_rev.embeddings.utils.tokenization import (
+    TokenLimitExceededError,
+    TokenizerCache,
+)
 from Medical_KG_rev.services.vector_store.models import VectorRecord
 from Medical_KG_rev.services.vector_store.service import VectorStoreService
 
@@ -27,11 +33,11 @@ logger = structlog.get_logger(__name__)
 
 @dataclass(slots=True)
 class EmbeddingRequest:
+    """Service-level embedding request used by orchestration."""
+
     tenant_id: str
-    chunk_ids: Sequence[str]
     texts: Sequence[str]
-    normalize: bool = False
-    batch_size: int = 8
+    chunk_ids: Sequence[str] | None = None
     models: Sequence[str] | None = None
     namespaces: Sequence[str] | None = None
     correlation_id: str | None = None
@@ -41,12 +47,14 @@ class EmbeddingRequest:
 
 @dataclass(slots=True)
 class EmbeddingVector:
+    """High-level representation of an embedding returned to callers."""
+
     id: str
     model: str
     namespace: str
     kind: str
-    vectors: list[list[float]] | None
-    terms: dict[str, float] | None
+    vectors: list[list[float]] | None = None
+    terms: dict[str, float] | None = None
     neural_fields: dict[str, object] | None = None
     dimension: int = 0
     model_version: str | None = None
@@ -58,7 +66,7 @@ class EmbeddingVector:
         cls,
         record: EmbeddingRecord,
         *,
-        storage_router: StorageRouter | None = None,
+        storage_router: StorageRouter,
     ) -> "EmbeddingVector":
         if record.dim is not None:
             dimension = record.dim
@@ -68,13 +76,11 @@ class EmbeddingVector:
             dimension = len(record.terms)
         else:
             dimension = 0
-        metadata = dict(record.metadata)
-        if storage_router is not None:
-            try:
-                target = storage_router.route(record.kind).name
-            except KeyError:  # pragma: no cover - defensive guard
-                target = "unmapped"
-            metadata.setdefault("storage_target", target)
+        metadata = {"provider": record.metadata.get("provider", ""), **record.metadata}
+        try:
+            metadata.setdefault("storage_target", storage_router.route(record.kind).name)
+        except KeyError:  # pragma: no cover - defensive guard
+            metadata.setdefault("storage_target", "unknown")
         metadata.setdefault("model_version", record.model_version)
         return cls(
             id=record.id,
@@ -92,195 +98,73 @@ class EmbeddingVector:
 
 
 @dataclass(slots=True)
-class _VectorBuilder:
-    """Helper that converts adapter records into response vectors."""
-
-    storage_router: StorageRouter
-
-    def build(self, record: EmbeddingRecord) -> EmbeddingVector:
-        return EmbeddingVector.from_record(record, storage_router=self.storage_router)
-
-
-@dataclass(slots=True)
-class EmbeddingResponse:
-    vectors: list[EmbeddingVector] = field(default_factory=list)
-
-    @property
-    def values(self) -> list[float] | None:
-        """Compatibility accessor returning the primary dense payload."""
-
-        if self.vectors:
-            # Return a copy so downstream normalization does not mutate
-            # the stored payload which may be re-used by other adapters.
-            return list(self.vectors[0])
-        return None
-
-    @property
-    def values(self) -> list[float] | None:
-        """Compatibility accessor returning the primary dense payload."""
-
-        if self.vectors:
-            # Return a copy so downstream normalization does not mutate
-            # the stored payload which may be re-used by other adapters.
-            return list(self.vectors[0])
-        return None
-
-
-@dataclass(slots=True)
 class EmbeddingResponse:
     vectors: list[EmbeddingVector] = field(default_factory=list)
 
 
 @dataclass(slots=True)
-class _LegacyEmbeddingModel:
-    name: str
-    dimension: int
-    kind: str
-
-    def embed(self, chunk_id: str, text: str) -> dict[str, object]:
-        tokens = text.split()
-        if self.kind == "dense":
-            base = float(len(tokens) or 1)
-            values = [round((base + index) % 7, 4) for index in range(self.dimension)]
-            return {"id": chunk_id, "values": values}
-        weights = {
-            f"{tokens[index % max(1, len(tokens))]}_{index}": round(1.0 - (index * 0.1), 4)
-            for index in range(min(self.dimension, max(1, len(tokens))))
-        }
-        return {"id": chunk_id, "terms": weights}
-
-
-class EmbeddingModelRegistry:
-    """Compatibility shim for legacy embedding registry usage in tests."""
-
-    def __init__(self, gpu_manager: object | None = None) -> None:  # noqa: ARG002 - parity
-        self.namespace_manager = NamespaceManager()
-        self._models: dict[str, _LegacyEmbeddingModel] = {
-            "splade": _LegacyEmbeddingModel(name="splade", dimension=64, kind="sparse"),
-            "bge": _LegacyEmbeddingModel(name="bge", dimension=128, kind="dense"),
-        }
-        self._aliases = {
-            "splade": "splade",
-            "sparse": "splade",
-            "bge": "bge",
-            "bge-small": "bge",
-            "dense": "bge",
-        }
-
-    def list_models(self) -> list[str]:
-        return list(self._models)
-
-    def get(self, name: str) -> _LegacyEmbeddingModel:
-        key = self._aliases.get(name, name)
-        try:
-            return self._models[key]
-        except KeyError as exc:  # pragma: no cover - defensive
-            raise KeyError(f"Unknown embedding model '{name}'") from exc
-
-
-@dataclass(slots=True)
-class _LegacyEmbeddingModel:
-    name: str
-    dimension: int
-    kind: str
-
-    def embed(self, chunk_id: str, text: str) -> dict[str, object]:
-        tokens = text.split()
-        if self.kind == "dense":
-            base = float(len(tokens) or 1)
-            values = [round((base + index) % 7, 4) for index in range(self.dimension)]
-            return {"id": chunk_id, "values": values}
-        weights = {
-            f"{tokens[index % max(1, len(tokens))]}_{index}": round(1.0 - (index * 0.1), 4)
-            for index in range(min(self.dimension, max(1, len(tokens))))
-        }
-        return {"id": chunk_id, "terms": weights}
-
-
-class EmbeddingModelRegistry:
-    """Compatibility shim for legacy embedding registry usage in tests."""
-
-    def __init__(self, gpu_manager: object | None = None) -> None:  # noqa: ARG002 - parity
-        self.namespace_manager = NamespaceManager()
-        self._models: dict[str, _LegacyEmbeddingModel] = {
-            "splade": _LegacyEmbeddingModel(name="splade", dimension=64, kind="sparse"),
-            "bge": _LegacyEmbeddingModel(name="bge", dimension=128, kind="dense"),
-        }
-        self._aliases = {
-            "splade": "splade",
-            "sparse": "splade",
-            "bge": "bge",
-            "bge-small": "bge",
-            "dense": "bge",
-        }
-
-    def list_models(self) -> list[str]:
-        return list(self._models)
-
-    def get(self, name: str) -> _LegacyEmbeddingModel:
-        key = self._aliases.get(name, name)
-        try:
-            return self._models[key]
-        except KeyError as exc:  # pragma: no cover - defensive
-            raise KeyError(f"Unknown embedding model '{name}'") from exc
-
-
 class EmbeddingWorker:
-    """Coordinates config-driven embedding generation and validation."""
+    """Coordinates config-driven embedding generation and storage."""
 
-    def __init__(
-        self,
-        registry_or_namespace: EmbeddingModelRegistry | NamespaceManager | None = None,
-        *,
-        namespace_manager: NamespaceManager | None = None,
-        config_path: str | None = None,
-    ) -> None:
-        self._legacy_registry: EmbeddingModelRegistry | None = None
-        if isinstance(registry_or_namespace, EmbeddingModelRegistry):
-            self._legacy_registry = registry_or_namespace
-            self.namespace_manager = registry_or_namespace.namespace_manager
-            self.registry = None
-            self.factory = None
-            self.storage_router = StorageRouter()
-            self._config = None
-            self._embedder_configs: list[EmbedderConfig] = []
-            self._configs_by_name: dict[str, EmbedderConfig] = {}
-            self._configs_by_namespace: dict[str, EmbedderConfig] = {}
-            return
+    model_registry: EmbeddingModelRegistry | None = None
+    namespace_manager: NamespaceManager | None = None
+    vector_store: VectorStoreService | None = None
+    config_path: str | None = None
+    tokenizer_cache: TokenizerCache | None = None
+    registry: EmbedderRegistry | None = field(init=False, default=None)
+    factory: EmbedderFactory | None = field(init=False, default=None)
+    storage_router: StorageRouter | None = field(init=False, default=None)
+    tokenizers: TokenizerCache | None = field(init=False, default=None)
 
-        if isinstance(registry_or_namespace, NamespaceManager) and namespace_manager is not None:
-            raise TypeError("namespace_manager should not be provided twice")
-        effective_namespace = namespace_manager
-        if effective_namespace is None and isinstance(registry_or_namespace, NamespaceManager):
-            effective_namespace = registry_or_namespace
-        self.namespace_manager = effective_namespace or NamespaceManager()
-        self.registry = EmbedderRegistry(namespace_manager=self.namespace_manager)
-        register_builtin_embedders(self.registry)
-        self.factory = EmbedderFactory(self.registry)
-        self.storage_router = StorageRouter()
-        self._config = load_embeddings_config(Path(config_path) if config_path else None)
-        self._embedder_configs = self._config.to_embedder_configs()
-        self._configs_by_name = {config.name: config for config in self._embedder_configs}
-        self._configs_by_namespace = {config.namespace: config for config in self._embedder_configs}
+    def __post_init__(self) -> None:
+        if self.model_registry is None:
+            self.model_registry = EmbeddingModelRegistry(
+                namespace_manager=self.namespace_manager,
+                config_path=self.config_path,
+            )
+        self.namespace_manager = self.model_registry.namespace_manager
+        self.registry = self.model_registry.registry
+        self.factory = self.model_registry.factory
+        self.storage_router = self.model_registry.storage_router
+        self.tokenizers = self.tokenizer_cache or TokenizerCache()
 
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
     def _resolve_configs(self, request: EmbeddingRequest) -> list[EmbedderConfig]:
         return self.model_registry.resolve(
             models=request.models,
             namespaces=request.namespaces,
         )
 
-    def _adapter_request(self, request: EmbeddingRequest, config: EmbedderConfig) -> AdapterEmbeddingRequest:
+    def _adapter_request(
+        self,
+        request: EmbeddingRequest,
+        config: EmbedderConfig,
+        *,
+        texts: Sequence[str],
+    ) -> AdapterEmbeddingRequest:
+        ids = list(request.chunk_ids or [])
+        if len(ids) < len(texts):
+            ids.extend(
+                f"{request.tenant_id}:{index}" for index in range(len(ids), len(texts))
+            )
+        else:
+            ids = ids[: len(texts)]
+        metadata = [dict(item) for item in list(request.metadatas or [])[: len(texts)]]
+        while len(metadata) < len(texts):
+            metadata.append({})
         return AdapterEmbeddingRequest(
             tenant_id=request.tenant_id,
             namespace=config.namespace,
             texts=list(texts),
-            ids=list(ids),
+            ids=ids,
             correlation_id=request.correlation_id,
-            metadata=[dict(item) for item in metadata],
+            metadata=metadata,
         )
 
     def _dimension_from_record(self, record: EmbeddingRecord) -> int:
-        if record.dim:
+        if record.dim is not None:
             return record.dim
         if record.vectors:
             return len(record.vectors[0])
@@ -288,50 +172,79 @@ class EmbeddingWorker:
             return len(record.terms)
         return 0
 
-    def _batch_iterator(
-        self, request: EmbeddingRequest, batch_size: int
-    ) -> Iterator[tuple[list[str], list[str], list[dict[str, object]]]]:
-        texts = list(request.texts)
-        ids = list(request.chunk_ids or [])
-        if len(ids) < len(texts):
-            ids.extend(f"{request.tenant_id}:{index}" for index in range(len(ids), len(texts)))
-        else:
-            ids = ids[: len(texts)]
-        metadata_list = [
-            dict(item) for item in list(request.metadatas or [])[: len(texts)]
-        ]
-        while len(metadata_list) < len(texts):
-            metadata_list.append({})
-        for start in range(0, len(texts), batch_size):
-            yield (
-                texts[start : start + batch_size],
-                ids[start : start + batch_size],
-                metadata_list[start : start + batch_size],
+    def _persist_dense(
+        self,
+        *,
+        request: EmbeddingRequest,
+        config: EmbedderConfig,
+        vectors: list[EmbeddingRecord],
+    ) -> None:
+        if not self.vector_store:
+            return
+        records: list[VectorRecord] = []
+        for record in vectors:
+            if not record.vectors:
+                continue
+            named_vectors: dict[str, list[float]] | None = None
+            if len(record.vectors) > 1:
+                named_vectors = {
+                    f"segment_{index}": list(vector)
+                    for index, vector in enumerate(record.vectors[1:], start=1)
+                }
+            records.append(
+                VectorRecord(
+                    vector_id=record.id,
+                    values=list(record.vectors[0]),
+                    metadata=dict(record.metadata),
+                    named_vectors=named_vectors,
+                )
             )
+        if not records:
+            return
+        context = SecurityContext(
+            subject="embedding-worker",
+            tenant_id=request.tenant_id,
+            scopes={"index:write"},
+        )
+        self.vector_store.upsert(
+            context=context,
+            namespace=config.namespace,
+            records=records,
+        )
 
+    def _token_budget(self, config: EmbedderConfig) -> int | None:
+        return config.parameters.get("max_tokens") if config.parameters else None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
     def run(self, request: EmbeddingRequest) -> EmbeddingResponse:
-        if self._legacy_registry is not None:
-            return self._run_legacy(request)
         configs = self._resolve_configs(request)
         response = EmbeddingResponse()
-        logger.info(
-            "embedding.pipeline.start",
-            tenant_id=request.tenant_id,
-            actor=request.actor,
-            chunks=len(request.texts),
-            models=[config.name for config in configs],
-        )
+        texts = list(request.texts)
         for config in configs:
-            ensure_available(config.requires_gpu, operation=f"embed:{config.name}")
+            ensure_available(config.requires_gpu, operation=f"embed:{config.namespace}")
             try:
-                embedder = self.model_registry.get(config)
-            except KeyError:
-                embedder = self.factory.get(config)
-            adapter_request = self._adapter_request(request, config)
+                self.tokenizers.ensure_within_limit(
+                    model_id=config.model_id,
+                    texts=texts,
+                    max_tokens=self._token_budget(config),
+                    correlation_id=request.correlation_id,
+                )
+            except TokenLimitExceededError:
+                logger.error(
+                    "embedding.token_limit_exceeded",
+                    namespace=config.namespace,
+                    model=config.model_id,
+                    correlation_id=request.correlation_id,
+                )
+                raise
+            embedder = self.model_registry.get(config)
+            adapter_request = self._adapter_request(request, config, texts=texts)
             records = embedder.embed_documents(adapter_request)
             if not records:
                 logger.warning(
-                    "embedding.pipeline.no_output",
+                    "embedding.no_records",
                     namespace=config.namespace,
                     model=config.name,
                 )
@@ -340,139 +253,48 @@ class EmbeddingWorker:
             dimension = self._dimension_from_record(first)
             if dimension:
                 self.namespace_manager.introspect_dimension(config.namespace, dimension)
-            vector_records: list[VectorRecord] = []
             for record in records:
                 dim = self._dimension_from_record(record)
                 self.namespace_manager.validate_record(config.namespace, dim)
-                metadata = {
-                    **record.metadata,
-                    "storage_target": self.storage_router.route(record.kind).name,
-                }
-                response.vectors.append(
-                    EmbeddingVector(
-                        id=record.id,
-                        model=record.model_id,
-                        namespace=record.namespace,
-                        kind=record.kind,
-                        vectors=record.vectors,
-                        terms=record.terms,
-                        dimension=dim,
-                        metadata=metadata,
-                    )
-                )
-                if self.vector_store and record.vectors:
-                    named_vectors: dict[str, list[float]] | None = None
-                    if len(record.vectors) > 1:
-                        named_vectors = {
-                            f"segment_{idx}": list(vector)
-                            for idx, vector in enumerate(record.vectors[1:], start=1)
-                        }
-                    vector_records.append(
-                        VectorRecord(
-                            vector_id=record.id,
-                            values=list(record.vectors[0]),
-                            metadata=metadata,
-                            named_vectors=named_vectors,
-                        )
-                    )
-            if self.vector_store and vector_records:
-                context = SecurityContext(
-                    subject="embedding-worker",
-                    tenant_id=request.tenant_id,
-                    scopes={"index:write"},
-                )
-                self.vector_store.upsert(
-                    context=context,
-                    namespace=config.namespace,
-                    records=vector_records,
-                )
+                vector = EmbeddingVector.from_record(record, storage_router=self.storage_router)
+                response.vectors.append(vector)
+            self._persist_dense(request=request, config=config, vectors=records)
             logger.info(
-                "embedding.pipeline.completed",
+                "embedding.namespace.completed",
                 namespace=config.namespace,
                 model=config.name,
-                actor=request.actor,
-                total=len(records),
-                duration_ms=(time.perf_counter() - start) * 1000,
+                records=len(records),
             )
-        logger.info(
-            "embedding.pipeline.finish",
-            total=len(response.vectors),
-            actor=request.actor,
-            tenant_id=request.tenant_id,
-        )
         return response
 
     def encode_queries(self, request: EmbeddingRequest) -> EmbeddingResponse:
         configs = self._resolve_configs(request)
         response = EmbeddingResponse()
         for config in configs:
-            ensure_available(config.requires_gpu, operation=f"embed-query:{config.name}")
-            embedder = self.factory.get(config)
-            adapter_request = self._adapter_request(
-                request,
-                config,
-                texts=request.texts,
-                ids=request.chunk_ids
-                or [f"query:{index}" for index in range(len(request.texts))],
-                metadata=request.metadatas or [{} for _ in request.texts],
-            )
+            ensure_available(config.requires_gpu, operation=f"embed-query:{config.namespace}")
+            embedder = self.model_registry.get(config)
+            adapter_request = self._adapter_request(request, config, texts=request.texts)
             records = embedder.embed_queries(adapter_request)
             for record in records:
                 dim = self._dimension_from_record(record)
                 self.namespace_manager.validate_record(config.namespace, dim)
-                response.vectors.append(self._vector_builder.build(record))
-        return response
-
-    def _run_legacy(self, request: EmbeddingRequest) -> EmbeddingResponse:
-        models = request.models or self._legacy_registry.list_models()
-        response = EmbeddingResponse()
-        for model_name in models:
-            model = self._legacy_registry.get(model_name)
-            for chunk_id, text in zip(request.chunk_ids, request.texts, strict=False):
-                result = model.embed(chunk_id, text)
-                metadata = {"source": "legacy"}
-                if model.kind == "dense":
-                    response.vectors.append(
-                        EmbeddingVector(
-                            id=result["id"],
-                            model=model.name,
-                            namespace=model.name,
-                            kind="dense",
-                            vectors=[result["values"]],
-                            terms=None,
-                            dimension=model.dimension,
-                            metadata=metadata,
-                        )
-                    )
-                else:
-                    response.vectors.append(
-                        EmbeddingVector(
-                            id=result["id"],
-                            model=model.name,
-                            namespace=model.name,
-                            kind="sparse",
-                            vectors=None,
-                            terms=result["terms"],
-                            dimension=model.dimension,
-                            metadata=metadata,
-                        )
-                    )
+                response.vectors.append(
+                    EmbeddingVector.from_record(record, storage_router=self.storage_router)
+                )
         return response
 
 
+@dataclass(slots=True)
 class EmbeddingGrpcService:
     """Async gRPC servicer bridging requests into the embedding worker."""
 
-    def __init__(self, worker: EmbeddingWorker) -> None:
-        self.worker = worker
+    worker: EmbeddingWorker
 
     async def EmbedChunks(self, request, context):  # type: ignore[override]
         embed_request = EmbeddingRequest(
             tenant_id=request.tenant_id,
-            chunk_ids=list(request.chunk_ids),
             texts=list(request.texts),
-            normalize=request.normalize,
-            batch_size=request.batch_size or 8,
+            chunk_ids=list(request.chunk_ids),
             models=list(request.models) or None,
             namespaces=list(request.namespaces) or None,
             correlation_id=getattr(request, "correlation_id", None),
@@ -489,10 +311,19 @@ class EmbeddingGrpcService:
             message.namespace = vector.namespace
             message.dimension = vector.dimension
             if vector.vectors:
-                for item in vector.vectors:
-                    payload = message.vectors.add()
-                    payload.values.extend(item)
+                for payload in vector.vectors:
+                    message_payload = message.vectors.add()
+                    message_payload.values.extend(payload)
             if vector.terms:
                 message.terms.update(vector.terms)
             message.metadata.update({key: str(value) for key, value in vector.metadata.items()})
         return reply
+
+
+__all__ = [
+    "EmbeddingGrpcService",
+    "EmbeddingRequest",
+    "EmbeddingResponse",
+    "EmbeddingVector",
+    "EmbeddingWorker",
+]

--- a/tests/embeddings/test_sparse.py
+++ b/tests/embeddings/test_sparse.py
@@ -1,46 +1,93 @@
 from Medical_KG_rev.embeddings.ports import EmbedderConfig, EmbeddingRequest
-from Medical_KG_rev.embeddings.sparse.splade import (
-    PyseriniSparseEmbedder,
-    SPLADEDocEmbedder,
-    build_rank_features_mapping,
-)
+import sys
+from types import ModuleType
+
+import pytest
+
+from Medical_KG_rev.embeddings.ports import EmbedderConfig, EmbeddingRequest
+from Medical_KG_rev.embeddings.sparse.splade import PyseriniSparseEmbedder, build_rank_features_mapping
 
 
-def _request(namespace: str) -> EmbeddingRequest:
-    return EmbeddingRequest(tenant_id="tenant", namespace=namespace, texts=["Token alpha beta"])
+@pytest.fixture(autouse=True)
+def fake_pyserini(monkeypatch: pytest.MonkeyPatch):
+    module = ModuleType("pyserini")
+    encode = ModuleType("pyserini.encode")
+
+    class DocumentEncoder:
+        called = 0
+
+        def __init__(self, model_id: str) -> None:
+            self.model_id = model_id
+
+        def encode(self, text: str, top_k: int = 400):  # noqa: D401 - mirrors Pyserini
+            DocumentEncoder.called += 1
+            tokens = [token for token in text.lower().split() if token]
+            return {token: float(index + 1) for index, token in enumerate(tokens[:top_k])}
+
+    class QueryEncoder(DocumentEncoder):
+        called = 0
+
+        def encode(self, text: str, top_k: int = 400):
+            QueryEncoder.called += 1
+            return super().encode(text, top_k=top_k)
+
+    encode.SpladeDocumentEncoder = DocumentEncoder
+    encode.SpladeQueryEncoder = QueryEncoder
+    module.encode = encode
+    monkeypatch.setitem(sys.modules, "pyserini", module)
+    monkeypatch.setitem(sys.modules, "pyserini.encode", encode)
+    yield
+    DocumentEncoder.called = 0
+    QueryEncoder.called = 0
 
 
-def test_splade_vocab_tracking() -> None:
+def _request(namespace: str, text: str = "Token alpha beta") -> EmbeddingRequest:
+    return EmbeddingRequest(tenant_id="tenant", namespace=namespace, texts=[text])
+
+
+def test_pyserini_document_expansion_respects_top_k() -> None:
     config = EmbedderConfig(
         name="splade",
-        provider="splade-doc",
-        kind="sparse",
-        namespace="sparse.splade.400.v1",
-        model_id="splade",
-        parameters={"normalization": "l1"},
-    )
-    embedder = SPLADEDocEmbedder(config)
-    request = _request(config.namespace)
-    embedder.embed_documents(request)
-    vocab = embedder.vocabulary_snapshot(2)
-    assert vocab
-
-
-def test_pyserini_normalization() -> None:
-    config = EmbedderConfig(
-        name="pyserini",
         provider="pyserini",
         kind="sparse",
-        namespace="sparse.pyserini.0.v1",
-        model_id="pyserini",
-        parameters={"normalization": "max"},
+        namespace="sparse.splade_v3.400.v1",
+        model_id="naver/splade-v3",
+        parameters={"top_k": 2},
     )
     embedder = PyseriniSparseEmbedder(config)
-    request = _request(config.namespace)
-    records = embedder.embed_documents(request)
+    records = embedder.embed_documents(_request(config.namespace))
     weights = records[0].terms
-    assert weights
-    assert max(weights.values()) == 1.0
+    assert weights is not None
+    assert len(weights) == 2
+    assert all(value > 0 for value in weights.values())
+
+
+def test_pyserini_query_mode_uses_query_encoder(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = EmbedderConfig(
+        name="splade-query",
+        provider="pyserini",
+        kind="sparse",
+        namespace="sparse.splade_query.400.v1",
+        model_id="naver/splade-v3",
+        parameters={"mode": "query", "top_k": 4},
+    )
+    embedder = PyseriniSparseEmbedder(config)
+    records = embedder.embed_queries(_request(config.namespace, text="diabetes treatment"))
+    weights = records[0].terms
+    assert weights and "diabetes" in weights
+
+
+def test_pyserini_handles_empty_text() -> None:
+    config = EmbedderConfig(
+        name="splade",
+        provider="pyserini",
+        kind="sparse",
+        namespace="sparse.splade_v3.400.v1",
+        model_id="naver/splade-v3",
+    )
+    embedder = PyseriniSparseEmbedder(config)
+    records = embedder.embed_documents(_request(config.namespace, text=""))
+    assert records[0].terms == {}
 
 
 def test_build_rank_features_mapping() -> None:

--- a/tests/services/embedding/test_embedding_vector_store.py
+++ b/tests/services/embedding/test_embedding_vector_store.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import pytest
 
-from Medical_KG_rev.embeddings.namespace import NamespaceManager, NamespaceConfig as EmbeddingNamespaceConfig
+from Medical_KG_rev.embeddings.namespace import NamespaceManager
+from Medical_KG_rev.embeddings.ports import EmbedderConfig, EmbeddingRecord
+from Medical_KG_rev.embeddings.utils.tokenization import TokenizerCache
 from Medical_KG_rev.auth.context import SecurityContext
 from Medical_KG_rev.services.embedding.service import (
     EmbeddingModelRegistry,
@@ -18,28 +20,19 @@ from Medical_KG_rev.services.vector_store.service import VectorStoreService
 
 class DummyEmbedder:
     def embed_documents(self, request):  # type: ignore[override]
-        class Record:
-            def __init__(self) -> None:
-                self.id = "chunk-1"
-                self.model_id = "test"
-                self.namespace = request.namespace
-                self.kind = "single_vector"
-                self.vectors = [
-                    [float(i) / 100 for i in range(128)]
-                ]
-                self.terms = None
-                self.metadata = {"foo": "bar"}
-                self.dim = 128
-
-        return [Record()]
-
-
-class StubEmbedderFactory:
-    def __init__(self, worker: EmbeddingWorker) -> None:
-        self.worker = worker
-
-    def get(self, config):  # type: ignore[override]
-        return DummyEmbedder()
+        return [
+            EmbeddingRecord(
+                id=request.ids[0] if request.ids else "chunk-1",
+                tenant_id=request.tenant_id,
+                namespace=request.namespace,
+                model_id="Qwen/Qwen2.5-Embedding-8B-Instruct",
+                model_version="v1",
+                kind="single_vector",
+                dim=4096,
+                vectors=[[float(i) / 100 for i in range(4096)]],
+                metadata={"foo": "bar", "provider": "vllm"},
+            )
+        ]
 
 
 class StubVectorStore:
@@ -72,102 +65,69 @@ class StubVectorStore:
 @pytest.fixture()
 def embedding_worker(monkeypatch: pytest.MonkeyPatch):
     namespace_manager = NamespaceManager()
-    namespace_manager._namespaces[  # type: ignore[attr-defined]
-        "single_vector.bge_small_en.384.v1"
-    ] = EmbeddingNamespaceConfig(
-        name="single_vector.bge_small_en.384.v1",
+    fake_config = EmbedderConfig(
+        name="qwen3",
+        provider="vllm",
         kind="single_vector",
-        expected_dim=128,
-        model_id="test",
+        namespace="single_vector.qwen3.4096.v1",
+        model_id="Qwen/Qwen2.5-Embedding-8B-Instruct",
         model_version="v1",
-        embedder_name="test",
+        dim=4096,
+        parameters={"max_tokens": 8192, "endpoint": "http://localhost:8001/v1"},
+        requires_gpu=False,
     )
-    namespace_manager._namespaces[  # type: ignore[attr-defined]
-        "default"
-    ] = EmbeddingNamespaceConfig(
-        name="default",
-        kind="single_vector",
-        expected_dim=128,
-        model_id="fake-model",
-        model_version="v1",
-        embedder_name="fake",
-    )
+    namespace_manager.register(fake_config)
     registry = NamespaceRegistry()
     vector_store_adapter = StubVectorStore()
     service = VectorStoreService(vector_store_adapter, registry)
-    class FakeConfig:
-        def __init__(self) -> None:
-            self.name = "fake"
-            self.namespace = "default"
-            self.requires_gpu = False
-            self.kind = "single_vector"
-            self.model_id = "fake-model"
-            self.model_version = "v1"
-            self.dim = 128
-
     worker = EmbeddingWorker(namespace_manager=namespace_manager, vector_store=service)
-    fake_config = FakeConfig()
+    worker.namespace_manager.register(fake_config)
 
-    monkeypatch.setattr(worker, "_resolve_configs", lambda request: [fake_config])
-    monkeypatch.setattr(worker, "factory", StubEmbedderFactory(worker))
+    monkeypatch.setattr(EmbeddingWorker, "_resolve_configs", lambda self, request: [fake_config])
+    monkeypatch.setattr(EmbeddingModelRegistry, "get", lambda self, config: DummyEmbedder())
+    monkeypatch.setattr(TokenizerCache, "ensure_within_limit", lambda *args, **kwargs: None)
     service.ensure_namespace(
         context=SecurityContext(subject="tester", tenant_id="tenant", scopes={"index:write"}),
         config=NamespaceConfig(
-            name="default",
-            params=IndexParams(dimension=128),
+            name=fake_config.namespace,
+            params=IndexParams(dimension=4096),
         ),
     )
-    assert registry.get(tenant_id="tenant", namespace="default")
-    return worker, vector_store_adapter
+    assert registry.get(tenant_id="tenant", namespace=fake_config.namespace)
+    return worker, vector_store_adapter, fake_config
 
 
 def test_worker_upserts_vectors(embedding_worker) -> None:
-    worker, vector_store = embedding_worker
+    worker, vector_store, config = embedding_worker
     request = EmbeddingRequest(
         tenant_id="tenant",
         chunk_ids=["chunk-1"],
         texts=["sample"],
     )
     response = worker.run(request)
-    assert response.vectors[0].metadata["storage_target"]
+    assert response.vectors[0].metadata["storage_target"] == "faiss"
     assert vector_store.records[0]["vector_id"] == "chunk-1"
-    assert vector_store.records[0]["namespace"] == "default"
+    assert vector_store.records[0]["namespace"] == config.namespace
 
 
 def test_worker_resolves_configs_via_registry(monkeypatch) -> None:
     namespace_manager = NamespaceManager()
-    namespace_manager._namespaces[  # type: ignore[attr-defined]
-        "default"
-    ] = EmbeddingNamespaceConfig(
-        name="default",
+    fake_config = EmbedderConfig(
+        name="qwen3",
+        provider="vllm",
         kind="single_vector",
-        expected_dim=128,
-        model_id="fake-model",
+        namespace="single_vector.qwen3.4096.v1",
+        model_id="Qwen/Qwen2.5-Embedding-8B-Instruct",
         model_version="v1",
-        embedder_name="fake",
+        dim=4096,
+        parameters={"max_tokens": 8192, "endpoint": "http://localhost:8001/v1"},
+        requires_gpu=False,
     )
 
     worker = EmbeddingWorker(namespace_manager=namespace_manager, vector_store=None)
+    worker.namespace_manager.register(fake_config)
+    monkeypatch.setattr(TokenizerCache, "ensure_within_limit", lambda *args, **kwargs: None)
 
-    fake_config = type(
-        "Config",
-        (),
-        {
-            "name": "fake",
-            "namespace": "default",
-            "requires_gpu": False,
-            "kind": "single_vector",
-            "model_id": "fake-model",
-            "model_version": "v1",
-            "dim": 128,
-        },
-    )()
-
-    monkeypatch.setattr(
-        EmbeddingModelRegistry,
-        "resolve",
-        lambda self, *, models=None, namespaces=None: [fake_config],
-    )
     monkeypatch.setattr(
         EmbeddingModelRegistry,
         "get",
@@ -176,12 +136,10 @@ def test_worker_resolves_configs_via_registry(monkeypatch) -> None:
 
     captured: dict[str, object | None] = {}
 
-    original = EmbeddingModelRegistry.resolve
-
     def tracking_resolve(self, *, models=None, namespaces=None):  # type: ignore[override]
         captured["models"] = models
         captured["namespaces"] = namespaces
-        return original(self, models=models, namespaces=namespaces)
+        return [fake_config]
 
     monkeypatch.setattr(EmbeddingModelRegistry, "resolve", tracking_resolve)
 
@@ -189,9 +147,9 @@ def test_worker_resolves_configs_via_registry(monkeypatch) -> None:
         tenant_id="tenant",
         chunk_ids=["chunk-1"],
         texts=["sample"],
-        namespaces=["default"],
+        namespaces=[fake_config.namespace],
     )
     worker.run(request)
 
-    assert captured["namespaces"] == ["default"]
+    assert captured["namespaces"] == [fake_config.namespace]
     assert captured["models"] is None


### PR DESCRIPTION
## Summary
- replace legacy embedding adapters with vLLM/OpenAI-compatible dense client and Pyserini SPLADE sparse implementation
- add tokenizer cache and namespace-aware embedding worker updates, plus refresh orchestration and storage wiring
- update configuration and unit tests for the new embedding pipeline and vector store integration

## Testing
- pytest tests/embeddings/test_sparse.py tests/embeddings/test_core.py tests/services/embedding/test_embedding_vector_store.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e5a6893284832f8efa6265489abb25