### PR TITLE
feat: harden chunking error handling and gRPC schema

### DIFF
--- a/src/Medical_KG_rev/chunking/configuration.py
+++ b/src/Medical_KG_rev/chunking/configuration.py
@@ -10,7 +10,7 @@ import yaml
 from pydantic import BaseModel, Field, ValidationError
 
 from .models import ChunkerConfig, Granularity
-from .exceptions import ChunkerConfigurationError
+from .exceptions import ChunkerConfigurationError, ProfileNotFoundError
 
 
 class ChunkerSettings(BaseModel):
@@ -81,8 +81,12 @@ class ChunkingConfig(BaseModel):
             raise ChunkerConfigurationError(str(exc)) from exc
 
     def profile_for_source(self, source: str | None) -> ChunkingProfile:
-        if source and source in self.profiles:
-            return self.profiles[source]
+        available = tuple(self.profiles.keys())
+        if source:
+            try:
+                return self.profiles[source]
+            except KeyError as exc:
+                raise ProfileNotFoundError(source, available) from exc
         try:
             return self.profiles[self.default_profile]
         except KeyError as exc:

--- a/src/Medical_KG_rev/chunking/exceptions.py
+++ b/src/Medical_KG_rev/chunking/exceptions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Sequence
+
 
 class ChunkingError(RuntimeError):
     """Base error for chunking related failures."""
@@ -25,3 +27,63 @@ class ChunkingUnavailableError(ChunkingError):
     def __init__(self, retry_after: float) -> None:
         super().__init__("Chunking temporarily unavailable due to repeated failures")
         self.retry_after = max(retry_after, 0.0)
+
+
+class ProfileNotFoundError(ChunkingError):
+    """Raised when a requested chunking profile does not exist."""
+
+    def __init__(self, profile: str, available: Sequence[str]) -> None:
+        self.profile = profile
+        self.available = tuple(sorted(available))
+        message = (
+            f"Chunking profile '{profile}' not found. Available: {', '.join(self.available) or 'none'}"
+        )
+        super().__init__(message)
+
+
+class TokenizerMismatchError(ChunkingError):
+    """Raised when the configured tokenizer is incompatible with the embedding model."""
+
+    def __init__(self, tokenizer: str, model: str) -> None:
+        self.tokenizer = tokenizer
+        self.model = model or "unknown"
+        message = (
+            f"Tokenizer '{self.tokenizer}' incompatible with embedding model '{self.model}'"
+        )
+        super().__init__(message)
+
+
+class ChunkingFailedError(ChunkingError):
+    """Raised when the chunking pipeline fails unexpectedly."""
+
+    def __init__(self, message: str, *, detail: str | None = None) -> None:
+        super().__init__(message)
+        self.detail = detail
+
+
+class MineruOutOfMemoryError(ChunkingError):
+    """Raised when MinerU exhausts GPU memory during processing."""
+
+    def __init__(self) -> None:
+        super().__init__("GPU out of memory. Retry later or reduce PDF size.")
+
+
+class MineruGpuUnavailableError(ChunkingError):
+    """Raised when MinerU cannot detect a healthy GPU backend."""
+
+    def __init__(self) -> None:
+        super().__init__("GPU required for PDF processing. Check GPU availability.")
+
+
+__all__ = [
+    "ChunkingError",
+    "ChunkerConfigurationError",
+    "ChunkerRegistryError",
+    "InvalidDocumentError",
+    "ChunkingUnavailableError",
+    "ProfileNotFoundError",
+    "TokenizerMismatchError",
+    "ChunkingFailedError",
+    "MineruOutOfMemoryError",
+    "MineruGpuUnavailableError",
+]

--- a/src/Medical_KG_rev/gateway/app.py
+++ b/src/Medical_KG_rev/gateway/app.py
@@ -14,6 +14,14 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from Medical_KG_rev.chunking.exceptions import (
+    ChunkingFailedError,
+    MineruGpuUnavailableError,
+    MineruOutOfMemoryError,
+    ProfileNotFoundError,
+    TokenizerMismatchError,
+)
+
 from ..config.settings import get_settings
 from ..observability import setup_observability
 from ..services.health import CheckResult, HealthService, success
@@ -234,8 +242,18 @@ def create_app() -> FastAPI:
             media_type="text/html",
         )
 
+    def _log_problem(event: str, detail: ProblemDetail) -> None:
+        logger.error(
+            event,
+            extra={
+                "correlation_id": get_correlation_id(),
+                "problem": detail.model_dump(mode="json"),
+            },
+        )
+
     @app.exception_handler(GatewayError)
     async def handle_gateway_error(_: Request, exc: GatewayError) -> JSONResponse:
+        _log_problem("gateway.error", exc.detail)
         return create_problem_response(exc.detail)
 
     @app.exception_handler(HTTPException)
@@ -245,6 +263,7 @@ def create_app() -> FastAPI:
             status=exc.status_code,
             type="https://httpstatuses.com/" + str(exc.status_code),
         )
+        _log_problem("gateway.http_error", detail)
         return create_problem_response(detail)
 
     @app.exception_handler(RequestValidationError)
@@ -256,6 +275,66 @@ def create_app() -> FastAPI:
             detail="One or more parameters are invalid.",
             extensions={"errors": exc.errors()},
         )
+        _log_problem("gateway.validation_error", detail)
+        return create_problem_response(detail)
+
+    @app.exception_handler(ProfileNotFoundError)
+    async def handle_profile_error(_: Request, exc: ProfileNotFoundError) -> JSONResponse:
+        detail = ProblemDetail(
+            title="Chunking profile not found",
+            status=400,
+            type="https://medical-kg/errors/chunking-profile-not-found",
+            detail=str(exc),
+            extensions={"available_profiles": list(getattr(exc, "available", []))},
+        )
+        _log_problem("gateway.chunking.profile_not_found", detail)
+        return create_problem_response(detail)
+
+    @app.exception_handler(TokenizerMismatchError)
+    async def handle_tokenizer_error(_: Request, exc: TokenizerMismatchError) -> JSONResponse:
+        detail = ProblemDetail(
+            title="Tokenizer mismatch",
+            status=500,
+            type="https://medical-kg/errors/tokenizer-mismatch",
+            detail=str(exc),
+        )
+        _log_problem("gateway.chunking.tokenizer_mismatch", detail)
+        return create_problem_response(detail)
+
+    @app.exception_handler(ChunkingFailedError)
+    async def handle_chunking_failed(_: Request, exc: ChunkingFailedError) -> JSONResponse:
+        message = exc.detail or str(exc) or "Chunking process failed"
+        detail = ProblemDetail(
+            title="Chunking failed",
+            status=500,
+            type="https://medical-kg/errors/chunking-failed",
+            detail=message,
+        )
+        _log_problem("gateway.chunking.failed", detail)
+        return create_problem_response(detail)
+
+    @app.exception_handler(MineruOutOfMemoryError)
+    async def handle_mineru_oom(_: Request, exc: MineruOutOfMemoryError) -> JSONResponse:
+        detail = ProblemDetail(
+            title="MinerU out of memory",
+            status=503,
+            type="https://medical-kg/errors/mineru-oom",
+            detail=str(exc),
+            extensions={"reason": "gpu_out_of_memory"},
+        )
+        _log_problem("gateway.mineru.out_of_memory", detail)
+        return create_problem_response(detail)
+
+    @app.exception_handler(MineruGpuUnavailableError)
+    async def handle_mineru_unavailable(_: Request, exc: MineruGpuUnavailableError) -> JSONResponse:
+        detail = ProblemDetail(
+            title="MinerU GPU unavailable",
+            status=503,
+            type="https://medical-kg/errors/mineru-gpu-unavailable",
+            detail=str(exc),
+            extensions={"reason": "gpu_unavailable"},
+        )
+        _log_problem("gateway.mineru.gpu_unavailable", detail)
         return create_problem_response(detail)
 
     return app

--- a/src/Medical_KG_rev/gateway/grpc/server.py
+++ b/src/Medical_KG_rev/gateway/grpc/server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 from datetime import datetime, timezone
+from typing import Any, Mapping
 
 import grpc
 
@@ -169,11 +170,24 @@ class IngestionService(
         self.service = service
 
     async def Submit(self, request, context):  # type: ignore[override]
+        options_payload: dict[str, Any] | None = None
+        if hasattr(request, "options") and request.HasField("options"):
+            opts = request.options
+            options_payload = {
+                "preserve_tables_html": opts.preserve_tables_html,
+                "sentence_splitter": opts.sentence_splitter,
+                "custom_token_budget": int(opts.custom_token_budget),
+                **dict(opts.metadata),
+            }
         ingestion_request = IngestionRequest(
             tenant_id=request.tenant_id,
             items=[{"id": item_id} for item_id in request.item_ids],
             metadata={"dataset": request.dataset},
+            profile=request.chunking_profile or None,
+            chunking_options=options_payload,
         )
+        if options_payload:
+            ingestion_request.metadata.setdefault("chunking_options", options_payload)
         result = self.service.ingest(request.dataset, ingestion_request)
         if ingestion_pb2 is None:
             return None
@@ -182,6 +196,13 @@ class IngestionService(
             response.operations.add(
                 job_id=status.job_id, status=status.status, message=status.message or ""
             )
+        estimated_chunks = 0
+        for status in result.operations:
+            count = status.metadata.get("chunks") if isinstance(status.metadata, Mapping) else None
+            if isinstance(count, int):
+                estimated_chunks += count
+        response.estimated_chunks = max(0, estimated_chunks)
+        response.profile_used = ingestion_request.profile or ""
         return response
 
 

--- a/src/Medical_KG_rev/gateway/models.py
+++ b/src/Medical_KG_rev/gateway/models.py
@@ -156,6 +156,7 @@ class IngestionRequest(BaseModel):
     priority: Literal["low", "normal", "high"] = "normal"
     metadata: dict[str, Any] = Field(default_factory=dict)
     profile: str | None = None
+    chunking_options: dict[str, Any] | None = None
 
 
 class PipelineIngestionRequest(IngestionRequest):

--- a/src/Medical_KG_rev/observability/metrics.py
+++ b/src/Medical_KG_rev/observability/metrics.py
@@ -63,6 +63,36 @@ CHUNK_SIZE = Histogram(
     "Distribution of chunk sizes by granularity",
     labelnames=("profile", "granularity"),
 )
+CHUNKING_DOCUMENTS = Counter(
+    "chunking_documents_total",
+    "Total documents processed by the chunking pipeline",
+    labelnames=("profile",),
+)
+CHUNKING_DURATION = Histogram(
+    "chunking_duration_seconds",
+    "Chunking duration distribution per profile",
+    labelnames=("profile",),
+    buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0),
+)
+CHUNKS_PER_DOCUMENT = Histogram(
+    "chunking_chunks_per_document",
+    "Distribution of chunk counts per document",
+    labelnames=("profile",),
+    buckets=(1, 2, 4, 8, 16, 32, 64, 128),
+)
+CHUNKING_FAILURES = Counter(
+    "medicalkg_chunking_errors_total",
+    "Chunking failures grouped by profile and error type",
+    labelnames=("profile", "error_type"),
+)
+MINERU_GATE_TRIGGERED = Counter(
+    "mineru_gate_triggered_total",
+    "Number of times the MinerU two-phase gate halted processing",
+)
+POSTPDF_START_TRIGGERED = Counter(
+    "postpdf_start_triggered_total",
+    "Number of times post-PDF resume was triggered",
+)
 CHUNKING_CIRCUIT_STATE = Gauge(
     "chunking_circuit_breaker_state",
     "Circuit breaker state for chunking pipeline (0=closed, 1=open, 2=half-open)",
@@ -282,6 +312,35 @@ def _increment_with_exemplar(metric, labels: tuple[str, ...], amount: float = 1.
 
 def observe_job_duration(operation: str, duration_seconds: float) -> None:
     JOB_DURATION.labels(operation=operation).observe(max(duration_seconds, 0.0))
+
+
+
+def record_chunking_document(profile: str, duration_seconds: float, chunks: int) -> None:
+    """Record metrics for a completed chunking operation."""
+
+    labels = (profile or "unknown",)
+    _increment_with_exemplar(CHUNKING_DOCUMENTS, labels)
+    _observe_with_exemplar(CHUNKING_DURATION, labels, max(duration_seconds, 0.0))
+    _observe_with_exemplar(CHUNKS_PER_DOCUMENT, labels, float(max(chunks, 0)))
+
+
+def record_chunking_failure(profile: str | None, error_type: str) -> None:
+    """Increment chunking failure counter for the supplied error type."""
+
+    labels = (profile or "unknown", error_type)
+    _increment_with_exemplar(CHUNKING_FAILURES, labels)
+
+
+def increment_mineru_gate_triggered() -> None:
+    """Increment the MinerU gate triggered counter."""
+
+    MINERU_GATE_TRIGGERED.inc()
+
+
+def increment_postpdf_start_triggered() -> None:
+    """Increment the post-PDF start triggered counter."""
+
+    POSTPDF_START_TRIGGERED.inc()
 
 
 

--- a/src/Medical_KG_rev/proto/ingestion.proto
+++ b/src/Medical_KG_rev/proto/ingestion.proto
@@ -4,10 +4,19 @@ package medicalkg.gateway.v1;
 
 option go_package = "github.com/your-org/medicalkg/gateway/v1";
 
+message ChunkingOptions {
+  bool preserve_tables_html = 1;
+  string sentence_splitter = 2;
+  uint32 custom_token_budget = 3;
+  map<string, string> metadata = 4;
+}
+
 message IngestionJobRequest {
   string tenant_id = 1;
   string dataset = 2;
   repeated string item_ids = 3;
+  string chunking_profile = 4;
+  ChunkingOptions options = 5;
 }
 
 message OperationStatus {
@@ -18,6 +27,8 @@ message OperationStatus {
 
 message IngestionJobResponse {
   repeated OperationStatus operations = 1;
+  uint32 estimated_chunks = 2;
+  string profile_used = 3;
 }
 
 service IngestionService {

--- a/src/Medical_KG_rev/services/chunking/events.py
+++ b/src/Medical_KG_rev/services/chunking/events.py
@@ -1,0 +1,232 @@
+"""CloudEvents emission utilities for chunking lifecycle."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import uuid
+from typing import Any
+
+try:  # pragma: no cover - optional dependency for structured CloudEvents
+    from cloudevents.http import CloudEvent  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback used in unit tests
+    class CloudEvent(dict):  # type: ignore[override]
+        """Minimal CloudEvent shim when the official dependency is unavailable."""
+
+        def __init__(self, attributes: dict[str, Any], data: dict[str, Any]):
+            super().__init__(attributes)
+            self.data = data
+
+        def keys(self):  # noqa: D401 - provide mapping-like interface
+            return super().keys()
+
+try:  # pragma: no cover - orchestration Kafka client optional in CI
+    from Medical_KG_rev.orchestration.kafka import KafkaClient
+except Exception:  # pragma: no cover - lightweight fallback
+    class KafkaClient:  # type: ignore[override]
+        """In-memory Kafka stub used when the orchestration stack is unavailable."""
+
+        def __init__(self) -> None:
+            self._topics: dict[str, list[dict[str, Any]]] = {}
+
+        def create_topics(self, topics):  # noqa: D401 - compatibility shim
+            for topic in topics:
+                self._topics.setdefault(topic, [])
+
+        def publish(self, topic: str, value: dict[str, Any], *, key=None, headers=None):  # noqa: D401
+            self._topics.setdefault(topic, []).append(value)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _base_attributes(event_type: str, *, subject: str, correlation_id: str | None) -> dict[str, Any]:
+    event_id = uuid.uuid4().hex
+    return {
+        "specversion": "1.0",
+        "type": event_type,
+        "source": "services.chunking",
+        "subject": subject,
+        "time": _now(),
+        "id": event_id,
+        "datacontenttype": "application/json",
+        "correlationid": correlation_id or event_id,
+    }
+
+
+def _to_message(event: CloudEvent) -> dict[str, Any]:
+    payload: dict[str, Any] = {key: event.get(key) for key in event.keys()}  # type: ignore[arg-type]
+    payload["data"] = event.data
+    return payload
+
+
+@dataclass(slots=True)
+class ChunkingEventEmitter:
+    """Publishes chunking lifecycle CloudEvents to Kafka."""
+
+    kafka: KafkaClient = field(default_factory=KafkaClient)
+    topic: str = "chunking.events.v1"
+
+    def __post_init__(self) -> None:
+        self.kafka.create_topics([self.topic])
+
+    def emit_started(
+        self,
+        *,
+        tenant_id: str,
+        document_id: str,
+        profile: str,
+        correlation_id: str | None,
+        source: str | None = None,
+    ) -> CloudEvent:
+        subject = f"tenant:{tenant_id}:document:{document_id}"
+        attributes = _base_attributes(
+            "com.medical-kg.chunking.started",
+            subject=subject,
+            correlation_id=correlation_id,
+        )
+        data = {
+            "tenant_id": tenant_id,
+            "document_id": document_id,
+            "profile": profile,
+            "source": source or "unknown",
+            "correlation_id": attributes["correlationid"],
+        }
+        event = CloudEvent(attributes, data)
+        self.kafka.publish(
+            self.topic,
+            value=_to_message(event),
+            key=attributes["correlationid"],
+            headers={"content-type": "application/cloudevents+json"},
+        )
+        return event
+
+    def emit_completed(
+        self,
+        *,
+        tenant_id: str,
+        document_id: str,
+        profile: str,
+        correlation_id: str | None,
+        duration_ms: float,
+        chunks: int,
+        average_tokens: float | None,
+        average_chars: float | None,
+    ) -> CloudEvent:
+        subject = f"tenant:{tenant_id}:document:{document_id}"
+        attributes = _base_attributes(
+            "com.medical-kg.chunking.completed",
+            subject=subject,
+            correlation_id=correlation_id,
+        )
+        data = {
+            "tenant_id": tenant_id,
+            "document_id": document_id,
+            "profile": profile,
+            "duration_ms": max(duration_ms, 0.0),
+            "chunks": max(chunks, 0),
+            "average_token_count": max(average_tokens or 0.0, 0.0),
+            "average_char_count": max(average_chars or 0.0, 0.0),
+            "correlation_id": attributes["correlationid"],
+        }
+        event = CloudEvent(attributes, data)
+        self.kafka.publish(
+            self.topic,
+            value=_to_message(event),
+            key=attributes["correlationid"],
+            headers={"content-type": "application/cloudevents+json"},
+        )
+        return event
+
+    def emit_failed(
+        self,
+        *,
+        tenant_id: str,
+        document_id: str,
+        profile: str,
+        correlation_id: str | None,
+        error_type: str,
+        message: str,
+    ) -> CloudEvent:
+        subject = f"tenant:{tenant_id}:document:{document_id}"
+        attributes = _base_attributes(
+            "com.medical-kg.chunking.failed",
+            subject=subject,
+            correlation_id=correlation_id,
+        )
+        data = {
+            "tenant_id": tenant_id,
+            "document_id": document_id,
+            "profile": profile,
+            "error_type": error_type,
+            "message": message,
+            "correlation_id": attributes["correlationid"],
+        }
+        event = CloudEvent(attributes, data)
+        self.kafka.publish(
+            self.topic,
+            value=_to_message(event),
+            key=attributes["correlationid"],
+            headers={"content-type": "application/cloudevents+json"},
+        )
+        return event
+
+    def emit_mineru_gate_waiting(
+        self,
+        *,
+        tenant_id: str,
+        job_id: str,
+        document_id: str,
+        reason: str,
+    ) -> CloudEvent:
+        subject = f"tenant:{tenant_id}:job:{job_id}"
+        attributes = _base_attributes(
+            "com.medical-kg.mineru.gate.waiting",
+            subject=subject,
+            correlation_id=None,
+        )
+        data = {
+            "tenant_id": tenant_id,
+            "job_id": job_id,
+            "document_id": document_id,
+            "reason": reason,
+            "correlation_id": attributes["correlationid"],
+        }
+        event = CloudEvent(attributes, data)
+        self.kafka.publish(
+            self.topic,
+            value=_to_message(event),
+            key=attributes["correlationid"],
+            headers={"content-type": "application/cloudevents+json"},
+        )
+        return event
+
+    def emit_postpdf_start_triggered(
+        self,
+        *,
+        job_id: str,
+        triggered_by: str,
+    ) -> CloudEvent:
+        subject = f"job:{job_id}"
+        attributes = _base_attributes(
+            "com.medical-kg.postpdf.start.triggered",
+            subject=subject,
+            correlation_id=None,
+        )
+        data = {
+            "job_id": job_id,
+            "triggered_by": triggered_by,
+            "correlation_id": attributes["correlationid"],
+        }
+        event = CloudEvent(attributes, data)
+        self.kafka.publish(
+            self.topic,
+            value=_to_message(event),
+            key=attributes["correlationid"],
+            headers={"content-type": "application/cloudevents+json"},
+        )
+        return event
+
+
+__all__ = ["ChunkingEventEmitter"]

--- a/src/Medical_KG_rev/services/ingestion/service.py
+++ b/src/Medical_KG_rev/services/ingestion/service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
+from collections import Counter, defaultdict
 from dataclasses import dataclass
 from time import perf_counter
 from typing import Mapping, Sequence
@@ -10,11 +10,22 @@ from typing import Mapping, Sequence
 import structlog
 
 from Medical_KG_rev.chunking import Chunk, ChunkingOptions, ChunkingService
+from Medical_KG_rev.chunking.exceptions import (
+    ChunkerConfigurationError,
+    ChunkingFailedError,
+    ChunkingUnavailableError,
+    InvalidDocumentError,
+    ProfileNotFoundError,
+    TokenizerMismatchError,
+)
 from Medical_KG_rev.models.ir import Document
 from Medical_KG_rev.observability.metrics import (
     observe_chunking_latency,
     record_chunk_size,
+    record_chunking_document,
+    record_chunking_failure,
 )
+from Medical_KG_rev.services.chunking.events import ChunkingEventEmitter
 
 logger = structlog.get_logger(__name__)
 
@@ -28,6 +39,10 @@ class ChunkingRun:
     duration_seconds: float
     chunks: Sequence[Chunk]
     granularity_counts: Mapping[str, int]
+    average_chars: float
+    average_tokens: float
+    section_distribution: Mapping[str, int]
+    intent_distribution: Mapping[str, int]
 
 
 class ChunkStorage:
@@ -63,9 +78,11 @@ class IngestionService:
         *,
         chunking_service: ChunkingService | None = None,
         storage: ChunkStorage | None = None,
+        events: ChunkingEventEmitter | None = None,
     ) -> None:
         self.chunking = chunking_service or ChunkingService()
         self.storage = storage or InMemoryChunkStorage()
+        self.events = events or ChunkingEventEmitter()
 
     def detect_profile(self, document: Document, source_hint: str | None) -> str:
         return source_hint or document.source or self.chunking.config.default_profile
@@ -79,23 +96,78 @@ class IngestionService:
         options: ChunkingOptions | None = None,
     ) -> ChunkingRun:
         profile = self.detect_profile(document, source_hint)
-        started = perf_counter()
-        chunks = list(
-            self.chunking.chunk_document(
-                document,
-                tenant_id=tenant_id,
-                source=profile,
-                options=options,
-            )
+        self.events.emit_started(
+            tenant_id=tenant_id,
+            document_id=document.id,
+            profile=profile,
+            correlation_id=None,
+            source=source_hint,
         )
+        started = perf_counter()
+        try:
+            chunks = list(
+                self.chunking.chunk_document(
+                    document,
+                    tenant_id=tenant_id,
+                    source=profile,
+                    options=options,
+                )
+            )
+        except (
+            ProfileNotFoundError,
+            TokenizerMismatchError,
+            ChunkingFailedError,
+            ChunkerConfigurationError,
+            InvalidDocumentError,
+            ChunkingUnavailableError,
+        ) as exc:
+            record_chunking_failure(profile, exc.__class__.__name__)
+            self.events.emit_failed(
+                tenant_id=tenant_id,
+                document_id=document.id,
+                profile=profile,
+                correlation_id=None,
+                error_type=exc.__class__.__name__,
+                message=str(exc),
+            )
+            raise
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            record_chunking_failure(profile, exc.__class__.__name__)
+            self.events.emit_failed(
+                tenant_id=tenant_id,
+                document_id=document.id,
+                profile=profile,
+                correlation_id=None,
+                error_type=exc.__class__.__name__,
+                message=str(exc),
+            )
+            raise
         duration = perf_counter() - started
         self._ensure_chunk_ids(document.id, chunks)
         self.storage.store(tenant_id, document.id, chunks)
         counts = defaultdict(int)
+        section_counts: Counter[str] = Counter()
+        intent_counts: Counter[str] = Counter()
+        token_totals = 0
+        length_totals = 0
         for chunk in chunks:
             counts[chunk.granularity] += 1
             record_chunk_size(profile, chunk.granularity, len(chunk.body))
+            section_label = chunk.section or chunk.meta.get("section", "unknown")
+            section_counts[section_label or "unknown"] += 1
+            intent_value = (
+                chunk.meta.get("intent_hint")
+                or chunk.meta.get("intent")
+                or "unspecified"
+            )
+            intent_counts[str(intent_value)] += 1
+            token_totals += int(chunk.meta.get("token_count", 0) or 0)
+            length_totals += len(chunk.body)
+        chunk_count = len(chunks)
+        average_chars = (length_totals / chunk_count) if chunk_count else 0.0
+        average_tokens = (token_totals / chunk_count) if chunk_count else 0.0
         observe_chunking_latency(profile, duration)
+        record_chunking_document(profile, duration, chunk_count)
         logger.info(
             "ingestion.chunked",
             document_id=document.id,
@@ -104,12 +176,36 @@ class IngestionService:
             chunks=len(chunks),
             duration=round(duration, 4),
         )
+        logger.info(
+            "ingestion.chunk_quality",
+            document_id=document.id,
+            tenant_id=tenant_id,
+            profile=profile,
+            average_chars=round(average_chars, 2),
+            average_tokens=round(average_tokens, 2),
+            section_distribution=dict(section_counts),
+            intent_distribution=dict(intent_counts),
+        )
+        self.events.emit_completed(
+            tenant_id=tenant_id,
+            document_id=document.id,
+            profile=profile,
+            correlation_id=None,
+            duration_ms=duration * 1000,
+            chunks=chunk_count,
+            average_tokens=average_tokens,
+            average_chars=average_chars,
+        )
         return ChunkingRun(
             document_id=document.id,
             profile=profile,
             duration_seconds=duration,
             chunks=chunks,
             granularity_counts=dict(counts),
+            average_chars=average_chars,
+            average_tokens=average_tokens,
+            section_distribution=dict(section_counts),
+            intent_distribution=dict(intent_counts),
         )
 
     def list_chunks(self, tenant_id: str, document_id: str) -> list[Chunk]:

--- a/src/Medical_KG_rev/services/mineru/__init__.py
+++ b/src/Medical_KG_rev/services/mineru/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "MineruRequest",
     "MineruResponse",
     "MineruOutOfMemoryError",
+    "MineruGpuUnavailableError",
 ]
 
 
@@ -13,6 +14,7 @@ def __getattr__(name: str):  # pragma: no cover - simple lazy import helper
     if name in __all__:
         from .service import (
             MineruGrpcService,
+            MineruGpuUnavailableError,
             MineruOutOfMemoryError,
             MineruProcessor,
             MineruRequest,
@@ -25,5 +27,6 @@ def __getattr__(name: str):  # pragma: no cover - simple lazy import helper
             "MineruRequest": MineruRequest,
             "MineruResponse": MineruResponse,
             "MineruOutOfMemoryError": MineruOutOfMemoryError,
+            "MineruGpuUnavailableError": MineruGpuUnavailableError,
         }[name]
     raise AttributeError(name)

--- a/src/Medical_KG_rev/services/mineru/service.py
+++ b/src/Medical_KG_rev/services/mineru/service.py
@@ -11,6 +11,10 @@ from importlib import metadata as importlib_metadata
 
 import structlog
 
+from Medical_KG_rev.chunking.exceptions import (
+    MineruGpuUnavailableError as ChunkingMineruGpuUnavailableError,
+    MineruOutOfMemoryError as ChunkingMineruOutOfMemoryError,
+)
 from Medical_KG_rev.config.settings import MineruSettings, get_settings
 from Medical_KG_rev.storage.object_store import FigureStorageClient
 
@@ -38,8 +42,20 @@ from .vllm_client import VLLMClient, VLLMClientError
 logger = structlog.get_logger(__name__)
 
 
-class MineruOutOfMemoryError(MineruCliError):
+class MineruOutOfMemoryError(MineruCliError, ChunkingMineruOutOfMemoryError):
     """Raised when MinerU CLI indicates an out-of-memory failure."""
+
+    def __init__(self) -> None:
+        ChunkingMineruOutOfMemoryError.__init__(self)
+        MineruCliError.__init__(self, str(self))
+
+
+class MineruGpuUnavailableError(MineruCliError, ChunkingMineruGpuUnavailableError):
+    """Raised when MinerU cannot access a healthy GPU backend."""
+
+    def __init__(self) -> None:
+        ChunkingMineruGpuUnavailableError.__init__(self)
+        MineruCliError.__init__(self, str(self))
 
 
 class MineruProcessor:
@@ -188,7 +204,7 @@ class MineruProcessor:
         reason = "oom" if self._looks_like_oom(str(exc)) else "cli-error"
         MINERU_CLI_FAILURES_TOTAL.labels(reason=reason).inc()
         if reason == "oom":
-            raise MineruOutOfMemoryError(str(exc)) from exc
+            raise MineruOutOfMemoryError() from exc
         return True
 
     def _ensure_mineru_version(self) -> str | None:
@@ -306,9 +322,7 @@ class MineruProcessor:
             finally:
                 loop.close()
         if not healthy:
-            raise RuntimeError(
-                f"vLLM server unavailable at {self._settings.vllm_server.base_url}"
-            )
+            raise MineruGpuUnavailableError()
 
 
 class MineruGrpcService:
@@ -387,5 +401,6 @@ __all__ = [
     "MineruRequest",
     "MineruBatchResponse",
     "MineruOutOfMemoryError",
+    "MineruGpuUnavailableError",
     "MineruGrpcService",
 ]


### PR DESCRIPTION
## Summary
- define chunking error taxonomy, expose MinerU GPU failures, and emit CloudEvents plus metrics during ingestion
- update ingestion service logging/metrics and FastAPI gateway error handling for the new error types
- extend the ingestion gRPC proto with chunking options/profile metadata and surface them in the server implementation

## Testing
- `buf generate` *(fails: command not found)*
- `buf breaking` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e622553578832f9404cea2c691d4eb