### PR TITLE
Add regression tests for PDF ingestion pipeline

### DIFF
--- a/openspec/changes/enhance-pdf-pipeline-testing/proposal.md
+++ b/openspec/changes/enhance-pdf-pipeline-testing/proposal.md
@@ -1,0 +1,22 @@
+# Proposal: enhance-pdf-pipeline-testing
+
+This implementation-focused change tightens regression coverage for the PDF ingestion pipeline by exercising the gateway routing
+logic, validating ledger metadata for MinerU resumptions, and asserting the Dagster resume sensor contract. No production code is
+modified beyond test scaffolding; the goal is to lock in behaviour defined by the existing topology specifications.
+
+## Objectives
+
+1. Confirm gateway routing surfaces the dedicated `pdf-two-phase` topology when PDF payloads arrive, and that ledger entries persist
+   the correlation metadata required by the resume sensor.
+2. Strengthen the PDF resume sensor test to guard the pipeline version tagging and resume stage semantics.
+3. Introduce a topology regression test so the `pdf_ir_ready` gate remains correctly defined.
+
+## Out of Scope
+
+- Changes to the pipeline topology YAML or runtime orchestrator implementations.
+- Updates to the MinerU adapter or download stages.
+
+## Validation Strategy
+
+- New unit tests for the gateway and topology loaders.
+- Enhanced sensor regression assertions.

--- a/openspec/changes/enhance-pdf-pipeline-testing/specs/gateway/spec.md
+++ b/openspec/changes/enhance-pdf-pipeline-testing/specs/gateway/spec.md
@@ -1,0 +1,25 @@
+# Gateway Specification Delta — enhance-pdf-pipeline-testing
+
+## MODIFIED Requirements
+
+### Requirement: Gateway SHALL route PDF ingestion jobs to the dedicated MinerU pipeline
+
+#### Scenario: Selecting pdf-two-phase for PMC datasets
+- GIVEN an ingestion request targeting dataset `pmc`
+- AND the Dagster orchestrator exposes the `pdf-two-phase` topology with PMC in its applicable sources
+- WHEN the gateway resolves the pipeline for the incoming item
+- THEN `pdf-two-phase` MUST be selected
+- AND the job ledger entry MUST persist the topology version and adapter request metadata used to resume the job
+
+#### Scenario: Falling back to pdf-two-phase for PDF document payloads
+- GIVEN an ingestion request targeting a dataset without an explicit topology mapping
+- AND the item metadata declares `document_type="pdf"`
+- WHEN the gateway resolves the pipeline
+- THEN `pdf-two-phase` MUST be selected to guarantee MinerU gating is engaged
+
+#### Scenario: Using the default auto pipeline for non-PDF payloads
+- GIVEN an ingestion request targeting an unmapped dataset
+- AND the item metadata is not flagged as a PDF
+- WHEN the gateway resolves the pipeline
+- THEN the generic `auto` topology MUST be selected
+

--- a/openspec/changes/enhance-pdf-pipeline-testing/specs/orchestration/spec.md
+++ b/openspec/changes/enhance-pdf-pipeline-testing/specs/orchestration/spec.md
@@ -1,0 +1,18 @@
+# Orchestration Specification Delta — enhance-pdf-pipeline-testing
+
+## MODIFIED Requirements
+
+### Requirement: Dagster SHALL expose the pdf_ir_ready resume contract for MinerU jobs
+
+#### Scenario: Resuming pdf-two-phase after MinerU signals readiness
+- GIVEN a ledger entry for pipeline `pdf-two-phase` marked `pdf_ir_ready=true`
+- WHEN the pdf_ir_ready_sensor evaluates the ledger
+- THEN it MUST emit a `RunRequest` carrying the stored pipeline version, correlation payload, and a `medical_kg.resume_stage="chunk"` tag
+
+#### Scenario: Guarding the pdf-two-phase topology gate configuration
+- GIVEN the pipeline loader parses `config/orchestration/pipelines/pdf-two-phase.yaml`
+- WHEN the topology is validated
+- THEN it MUST include a gate named `pdf_ir_ready` that resumes stage `chunk`
+- AND the gate condition MUST watch the `pdf_ir_ready` ledger field with timeout `900` seconds and poll interval `10.0` seconds
+- AND the topology stages MUST include `download` and `gate_pdf_ir_ready` to enforce MinerU gating semantics
+

--- a/openspec/changes/enhance-pdf-pipeline-testing/tasks.md
+++ b/openspec/changes/enhance-pdf-pipeline-testing/tasks.md
@@ -1,0 +1,5 @@
+# enhance-pdf-pipeline-testing Implementation Tasks
+
+- [x] Add gateway unit tests covering PDF ingestion pipeline resolution, ensuring MinerU jobs record pipeline metadata in the ledger.
+- [x] Expand Dagster PDF resume sensor assertions to validate pipeline version, resume stage tagging, and payload propagation.
+- [x] Validate PDF pipeline topology configuration via tests to guarantee the gate definition and resume semantics remain stable.

--- a/tests/gateway/test_gateway_pdf_ingest.py
+++ b/tests/gateway/test_gateway_pdf_ingest.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from Medical_KG_rev.gateway.models import IngestionRequest
+from Medical_KG_rev.gateway.services import GatewayService
+from Medical_KG_rev.gateway.sse.manager import EventStreamManager
+from Medical_KG_rev.orchestration.dagster.configuration import PipelineConfigLoader
+from Medical_KG_rev.orchestration.dagster.runtime import DagsterRunResult
+from Medical_KG_rev.orchestration.ledger import JobLedger
+
+
+class _StubOrchestrator:
+    """Minimal orchestrator stub exposing pipeline metadata for tests."""
+
+    def __init__(self, loader: PipelineConfigLoader, pipelines: list[str]) -> None:
+        self.pipeline_loader = loader
+        self._pipelines = list(pipelines)
+        self.submissions: list[dict[str, object]] = []
+
+    def available_pipelines(self) -> list[str]:
+        return list(self._pipelines)
+
+    def submit(self, *, pipeline: str, context, adapter_request, payload) -> DagsterRunResult:  # noqa: ANN001 - protocol
+        self.submissions.append(
+            {
+                "pipeline": pipeline,
+                "context": context,
+                "adapter_request": adapter_request,
+                "payload": payload,
+            }
+        )
+        return DagsterRunResult(
+            pipeline=pipeline,
+            success=True,
+            state={"context": context, "payload": payload},
+            dagster_result=SimpleNamespace(success=True),
+        )
+
+
+@pytest.fixture()
+def gateway_service() -> GatewayService:
+    loader = PipelineConfigLoader("config/orchestration/pipelines")
+    orchestrator = _StubOrchestrator(loader, ["auto", "pdf-two-phase"])
+    service = GatewayService(
+        events=EventStreamManager(),
+        orchestrator=orchestrator,  # type: ignore[arg-type]
+        ledger=JobLedger(),
+    )
+    service._orchestrator_stub = orchestrator  # type: ignore[attr-defined]
+    return service
+
+
+def test_resolve_pipeline_prefers_pdf_for_pmc(gateway_service: GatewayService) -> None:
+    service = gateway_service
+    pipeline = service._resolve_pipeline("pmc", {"id": "doc-123"})
+    assert pipeline == "pdf-two-phase"
+
+
+def test_resolve_pipeline_falls_back_to_pdf_document_type(gateway_service: GatewayService) -> None:
+    service = gateway_service
+    pipeline = service._resolve_pipeline(
+        "unknown-source",
+        {"id": "doc-456", "document_type": "pdf"},
+    )
+    assert pipeline == "pdf-two-phase"
+
+
+def test_resolve_pipeline_defaults_to_auto_for_non_pdf(gateway_service: GatewayService) -> None:
+    service = gateway_service
+    pipeline = service._resolve_pipeline(
+        "unknown-source",
+        {"id": "doc-789", "document_type": "html"},
+    )
+    assert pipeline == "auto"
+
+
+def test_submit_dagster_job_records_pdf_metadata(gateway_service: GatewayService) -> None:
+    service = gateway_service
+    orchestrator: _StubOrchestrator = service._orchestrator_stub  # type: ignore[attr-defined]
+
+    request = IngestionRequest(
+        tenant_id="tenant-a",
+        items=[{"id": "pmc-001", "document_type": "pdf"}],
+        metadata={"source": "pmc"},
+    )
+
+    status = service._submit_dagster_job(
+        dataset="pmc",
+        request=request,
+        item=request.items[0],
+        metadata={"source": "pmc"},
+    )
+
+    assert status.status == "completed"
+    assert status.metadata["pipeline"] == "pdf-two-phase"
+    assert status.metadata["duplicate"] is False
+    assert orchestrator.submissions, "expected Dagster submission"
+    submission = orchestrator.submissions[0]
+    assert submission["pipeline"] == "pdf-two-phase"
+
+    entry = service.ledger.get(status.job_id)
+    assert entry is not None
+    assert entry.metadata["pipeline_version"] == "2025-01-01"
+    assert entry.metadata["payload"]["dataset"] == "pmc"
+    assert entry.metadata["adapter_request"]["parameters"]["dataset"] == "pmc"

--- a/tests/orchestration/test_dagster_sensors.py
+++ b/tests/orchestration/test_dagster_sensors.py
@@ -49,3 +49,12 @@ def test_pdf_ir_sensor_emits_run_request() -> None:
     ctx_config = request.run_config["ops"]["bootstrap"]["config"]["context"]
     assert ctx_config["job_id"] == job_id
     assert ctx_config["pipeline_name"] == "pdf-two-phase"
+    assert ctx_config["pipeline_version"] == "2025-01-01"
+
+    payload_config = request.run_config["ops"]["bootstrap"]["config"]["payload"]
+    assert payload_config == {"dataset": "pmc", "item": {"id": "doc-sensor"}}
+
+    adapter_config = request.run_config["ops"]["bootstrap"]["config"]["adapter_request"]
+    assert adapter_config["parameters"]["dataset"] == "pmc"
+
+    assert request.tags["medical_kg.resume_stage"] == "chunk"

--- a/tests/orchestration/test_pipeline_topology_pdf.py
+++ b/tests/orchestration/test_pipeline_topology_pdf.py
@@ -1,0 +1,17 @@
+from Medical_KG_rev.orchestration.dagster.configuration import PipelineConfigLoader
+
+
+def test_pdf_pipeline_declares_gate_configuration() -> None:
+    loader = PipelineConfigLoader("config/orchestration/pipelines")
+    topology = loader.load("pdf-two-phase")
+
+    stage_names = {stage.name for stage in topology.stages}
+    assert {"download", "gate_pdf_ir_ready"}.issubset(stage_names)
+
+    assert topology.gates, "expected gate definitions for pdf-two-phase"
+    gate = next(g for g in topology.gates if g.name == "pdf_ir_ready")
+    assert gate.resume_stage == "chunk"
+    assert gate.condition.field == "pdf_ir_ready"
+    assert gate.condition.equals is True
+    assert gate.condition.timeout_seconds == 900
+    assert gate.condition.poll_interval_seconds == 10.0


### PR DESCRIPTION
## Summary
- add gateway-focused unit tests that exercise PDF pipeline resolution and ledger metadata
- strengthen the Dagster pdf_ir_ready sensor assertions and topology regression coverage
- record the enhance-pdf-pipeline-testing change tasks and deltas under openspec

## Testing
- pytest tests/gateway/test_gateway_pdf_ingest.py tests/orchestration/test_dagster_sensors.py tests/orchestration/test_pipeline_topology_pdf.py *(fails: missing dependencies `pydantic`, `dagster` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e647ba4860832fa2b0f38176a5198a