### PR TITLE
Introduce typed pipeline state and JSON:API presenter

### DIFF
--- a/src/Medical_KG_rev/gateway/presentation/dependencies.py
+++ b/src/Medical_KG_rev/gateway/presentation/dependencies.py
@@ -1,0 +1,19 @@
+"""Dependency providers for presentation layer components."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from .interface import ResponsePresenter
+from .jsonapi import JSONAPIPresenter
+
+
+@lru_cache(maxsize=1)
+def _default_presenter() -> ResponsePresenter:
+    return JSONAPIPresenter()
+
+
+def get_response_presenter() -> ResponsePresenter:
+    """Return the default response presenter instance."""
+
+    return _default_presenter()

--- a/src/Medical_KG_rev/gateway/presentation/interface.py
+++ b/src/Medical_KG_rev/gateway/presentation/interface.py
@@ -1,0 +1,35 @@
+"""Presentation layer interfaces for HTTP payload shaping."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Protocol
+
+from fastapi import Response
+
+
+class ResponsePresenter(Protocol):
+    """Protocol describing presentation responsibilities for route handlers."""
+
+    def success(
+        self,
+        data: Any,
+        *,
+        status_code: int = 200,
+        meta: Mapping[str, Any] | None = None,
+    ) -> Response:
+        """Render a successful response with the given payload."""
+
+    def error(
+        self,
+        detail: Mapping[str, Any] | str,
+        *,
+        status_code: int = 400,
+    ) -> Response:
+        """Render an error payload in the transport format."""
+
+
+class RequestParser(Protocol):
+    """Protocol for request parsers extracting structured information."""
+
+    def parse(self, raw: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Convert the raw mapping into a structured payload."""

--- a/src/Medical_KG_rev/gateway/presentation/jsonapi.py
+++ b/src/Medical_KG_rev/gateway/presentation/jsonapi.py
@@ -1,0 +1,51 @@
+"""JSON:API presenter implementation for REST responses."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, Mapping
+
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from .interface import ResponsePresenter
+
+JSONAPI_CONTENT_TYPE = "application/vnd.api+json"
+
+
+def _normalise_payload(data: Any) -> Any:
+    if isinstance(data, BaseModel):
+        return data.model_dump(mode="json")
+    if isinstance(data, Iterable) and not isinstance(data, (str, bytes, dict)):
+        return [
+            item.model_dump(mode="json") if isinstance(item, BaseModel) else item for item in data
+        ]
+    return data
+
+
+class JSONAPIPresenter(ResponsePresenter):
+    """Presenter producing JSON:API compliant envelopes."""
+
+    media_type = JSONAPI_CONTENT_TYPE
+
+    def success(
+        self,
+        data: Any,
+        *,
+        status_code: int = 200,
+        meta: Mapping[str, Any] | None = None,
+    ) -> JSONResponse:
+        payload = {"data": _normalise_payload(data), "meta": dict(meta or {})}
+        return JSONResponse(payload, status_code=status_code, media_type=self.media_type)
+
+    def error(
+        self,
+        detail: Mapping[str, Any] | str,
+        *,
+        status_code: int = 400,
+    ) -> JSONResponse:
+        if isinstance(detail, Mapping):
+            payload = {"errors": [_normalise_payload(detail)]}
+        else:
+            payload = {"errors": [{"detail": detail}]}
+        return JSONResponse(payload, status_code=status_code, media_type=self.media_type)

--- a/src/Medical_KG_rev/gateway/presentation/odata.py
+++ b/src/Medical_KG_rev/gateway/presentation/odata.py
@@ -1,0 +1,37 @@
+"""Utilities for parsing OData style query parameters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import Request
+
+
+@dataclass(slots=True)
+class ODataParams:
+    select: list[str] | None = None
+    expand: list[str] | None = None
+    filter: str | None = None
+    top: int | None = None
+    skip: int | None = None
+
+    @classmethod
+    def from_request(cls, request: Request) -> ODataParams:
+        params: dict[str, Any] = {}
+        qp = request.query_params
+        if "$select" in qp:
+            params["select"] = [
+                value.strip() for value in qp["$select"].split(",") if value.strip()
+            ]
+        if "$expand" in qp:
+            params["expand"] = [
+                value.strip() for value in qp["$expand"].split(",") if value.strip()
+            ]
+        if "$filter" in qp:
+            params["filter"] = qp["$filter"]
+        if "$top" in qp:
+            params["top"] = int(qp["$top"])
+        if "$skip" in qp:
+            params["skip"] = int(qp["$skip"])
+        return cls(**params)

--- a/src/Medical_KG_rev/gateway/rest/router.py
+++ b/src/Medical_KG_rev/gateway/rest/router.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, TypeVar, cast
+from typing import Annotated, Any, TypeVar, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from ...auth import Scopes, SecurityContext, secure_endpoint
 from ...auth.audit import get_audit_trail
@@ -36,69 +35,14 @@ from ..models import (
     RetrievalResult,
     RetrieveRequest,
 )
+from ..presentation.dependencies import get_response_presenter
+from ..presentation.interface import ResponsePresenter
+from ..presentation.odata import ODataParams
 from ..services import GatewayService, get_gateway_service
 from ..services.retrieval.routing import QueryIntent
 
 router = APIRouter(prefix="/v1", tags=["gateway"])
 health_router = APIRouter(tags=["system"])
-
-
-class ODataParams(BaseModel):
-    select: list[str] | None = None
-    expand: list[str] | None = None
-    filter: str | None = Field(default=None, alias="$filter")
-    top: int | None = Field(default=None, alias="$top")
-    skip: int | None = Field(default=None, alias="$skip")
-
-    @classmethod
-    def from_request(cls, request: Request) -> ODataParams:
-        params: dict[str, Any] = {}
-        qp = request.query_params
-        if "$select" in qp:
-            params["select"] = [
-                value.strip() for value in qp["$select"].split(",") if value.strip()
-            ]
-        if "$expand" in qp:
-            params["expand"] = [
-                value.strip() for value in qp["$expand"].split(",") if value.strip()
-            ]
-        if "$filter" in qp:
-            params["$filter"] = qp["$filter"]
-        if "$top" in qp:
-            params["$top"] = int(qp["$top"])
-        if "$skip" in qp:
-            params["$skip"] = int(qp["$skip"])
-        return cls.model_validate(params)
-
-
-JSONAPI_CONTENT_TYPE = "application/vnd.api+json"
-
-
-def _normalise_payload(data: Any) -> Any:
-    if isinstance(data, BaseModel):
-        return data.model_dump(mode="json")
-    if isinstance(data, Iterable) and not isinstance(data, (str, bytes, dict)):
-        return [
-            item.model_dump(mode="json") if isinstance(item, BaseModel) else item for item in data
-        ]
-    return data
-
-
-def json_api_payload(data: Any, meta: dict[str, Any] | None = None) -> dict[str, Any]:
-    return {"data": _normalise_payload(data), "meta": meta or {}}
-
-
-def json_api_response(
-    data: Any,
-    *,
-    status_code: int = 200,
-    meta: dict[str, Any] | None = None,
-) -> JSONResponse:
-    return JSONResponse(
-        json_api_payload(data, meta=meta),
-        status_code=status_code,
-        media_type=JSONAPI_CONTENT_TYPE,
-    )
 
 
 @router.get("/adapters", response_model=None)
@@ -108,12 +52,13 @@ async def list_adapters(
     security: SecurityContext = Depends(
         secure_endpoint(scopes=[Scopes.ADAPTERS_READ], endpoint="GET /v1/adapters")
     ),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     try:
         adapters = service.list_adapters(domain)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    return json_api_response(adapters, meta={"total": len(adapters)})
+    return presenter.success(adapters, meta={"total": len(adapters)})
 
 
 @router.get("/adapters/{name}/metadata", response_model=None)
@@ -123,11 +68,12 @@ async def get_adapter_metadata(
     security: SecurityContext = Depends(
         secure_endpoint(scopes=[Scopes.ADAPTERS_READ], endpoint="GET /v1/adapters/{name}/metadata")
     ),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     metadata = service.get_adapter_metadata(name)
     if metadata is None:
         raise HTTPException(status_code=404, detail="Adapter not found")
-    return json_api_response(metadata)
+    return presenter.success(metadata)
 
 
 @router.get("/adapters/{name}/health", response_model=None)
@@ -137,11 +83,12 @@ async def get_adapter_health(
     security: SecurityContext = Depends(
         secure_endpoint(scopes=[Scopes.ADAPTERS_READ], endpoint="GET /v1/adapters/{name}/health")
     ),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     health = service.get_adapter_health(name)
     if health is None:
         raise HTTPException(status_code=404, detail="Adapter not found")
-    return json_api_response(health)
+    return presenter.success(health)
 
 
 @router.get("/adapters/{name}/config-schema", response_model=None)
@@ -153,11 +100,12 @@ async def get_adapter_config_schema(
             scopes=[Scopes.ADAPTERS_READ], endpoint="GET /v1/adapters/{name}/config-schema"
         )
     ),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     schema = service.get_adapter_config_schema(name)
     if schema is None:
         raise HTTPException(status_code=404, detail="Adapter not found")
-    return json_api_response(schema)
+    return presenter.success(schema)
 
 
 @health_router.get("/health", include_in_schema=True)
@@ -173,6 +121,7 @@ async def readiness_check(request: Request) -> JSONResponse:
 
 
 TModel = TypeVar("TModel", bound=BaseModel)
+PresenterDep = Annotated[ResponsePresenter, Depends(get_response_presenter)]
 
 
 def _ensure_tenant(
@@ -198,6 +147,7 @@ async def ingest_dataset(
         secure_endpoint(scopes=[Scopes.INGEST_WRITE], endpoint="POST /v1/ingest")
     ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     request = _ensure_tenant(request, security, http_request)  # type: ignore[assignment]
     result: BatchOperationResult = service.ingest(dataset, request)
@@ -208,7 +158,7 @@ async def ingest_dataset(
         resource=f"dataset:{dataset}",
         metadata={"items": len(request.items)},
     )
-    return json_api_response(result.operations, status_code=207, meta=meta)
+    return presenter.success(result.operations, status_code=207, meta=meta)
 
 
 @router.post("/pipelines/ingest", status_code=207, response_model=None)
@@ -219,6 +169,7 @@ async def ingest_pipeline(
         secure_endpoint(scopes=[Scopes.INGEST_WRITE], endpoint="POST /v1/pipelines/ingest")
     ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     request = _ensure_tenant(request, security, http_request)  # type: ignore[assignment]
     ingest_request = IngestionRequest.model_validate(
@@ -239,7 +190,7 @@ async def ingest_pipeline(
             "profile": request.profile,
         },
     )
-    return json_api_response(result.operations, status_code=207, meta=meta)
+    return presenter.success(result.operations, status_code=207, meta=meta)
 
 
 @router.get("/jobs/{job_id}", status_code=200, response_model=JobStatus)
@@ -249,11 +200,12 @@ async def get_job(
         secure_endpoint(scopes=[Scopes.JOBS_READ], endpoint="GET /v1/jobs/{job_id}")
     ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     job = service.get_job(job_id, tenant_id=security.tenant_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
-    return json_api_response(job)
+    return presenter.success(job)
 
 
 @router.get("/jobs/{job_id}/events", status_code=200)
@@ -269,6 +221,7 @@ async def list_job_events(
         secure_endpoint(scopes=[Scopes.JOBS_READ], endpoint="GET /v1/jobs/{job_id}/events")
     ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     job = service.get_job(job_id, tenant_id=security.tenant_id)
     if not job:
@@ -286,7 +239,7 @@ async def list_job_events(
     meta = {"job_id": job_id, "count": len(data)}
     if since is not None:
         meta["since"] = since.isoformat()
-    return json_api_response(data, meta=meta)
+    return presenter.success(data, meta=meta)
 
 
 @router.get("/jobs", status_code=200, response_model=list[JobStatus])
@@ -296,10 +249,11 @@ async def list_jobs(
         secure_endpoint(scopes=[Scopes.JOBS_READ], endpoint="GET /v1/jobs")
     ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     jobs = service.list_jobs(status=status, tenant_id=security.tenant_id)
     meta = {"total": len(jobs), "status": status}
-    return json_api_response(jobs, meta=meta)
+    return presenter.success(jobs, meta=meta)
 
 
 @router.post("/jobs/{job_id}/cancel", status_code=202, response_model=JobStatus)
@@ -309,6 +263,7 @@ async def cancel_job(
         secure_endpoint(scopes=[Scopes.JOBS_WRITE], endpoint="POST /v1/jobs/{job_id}/cancel")
     ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     job = service.cancel_job(job_id, tenant_id=security.tenant_id, reason="client-request")
     if not job:
@@ -319,34 +274,53 @@ async def cancel_job(
         resource=f"job:{job_id}",
         metadata={"reason": "client-request"},
     )
-    return json_api_response(job, status_code=202)
+    return presenter.success(job, status_code=202)
 
 
 @router.post("/ingest/clinicaltrials", status_code=207, include_in_schema=False)
 async def ingest_clinicaltrials(
     request: IngestionRequest,
     http_request: Request,
+    security: SecurityContext = Depends(
+        secure_endpoint(scopes=[Scopes.INGEST_WRITE], endpoint="POST /v1/ingest/clinicaltrials")
+    ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
-    return await ingest_dataset("clinicaltrials", request, http_request, service)
+    return await ingest_dataset(
+        "clinicaltrials",
+        request,
+        http_request,
+        security,
+        service,
+        presenter,
+    )
 
 
 @router.post("/ingest/dailymed", status_code=207, include_in_schema=False)
 async def ingest_dailymed(
     request: IngestionRequest,
     http_request: Request,
+    security: SecurityContext = Depends(
+        secure_endpoint(scopes=[Scopes.INGEST_WRITE], endpoint="POST /v1/ingest/dailymed")
+    ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
-    return await ingest_dataset("dailymed", request, http_request, service)
+    return await ingest_dataset("dailymed", request, http_request, security, service, presenter)
 
 
 @router.post("/ingest/pmc", status_code=207, include_in_schema=False)
 async def ingest_pmc(
     request: IngestionRequest,
     http_request: Request,
+    security: SecurityContext = Depends(
+        secure_endpoint(scopes=[Scopes.INGEST_WRITE], endpoint="POST /v1/ingest/pmc")
+    ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
-    return await ingest_dataset("pmc", request, http_request, service)
+    return await ingest_dataset("pmc", request, http_request, security, service, presenter)
 
 
 @router.post("/chunk", status_code=200)
@@ -357,6 +331,7 @@ async def chunk_document(
         secure_endpoint(scopes=[Scopes.INGEST_WRITE], endpoint="POST /v1/chunk")
     ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     request = _ensure_tenant(request, security, http_request)  # type: ignore[assignment]
     chunks = service.chunk_document(request)
@@ -367,7 +342,7 @@ async def chunk_document(
         resource=f"document:{request.document_id}",
         metadata={"chunks": len(chunks)},
     )
-    return json_api_response(chunks, meta=meta)
+    return presenter.success(chunks, meta=meta)
 
 
 @router.post("/embed", status_code=200)
@@ -378,6 +353,7 @@ async def embed_text(
         secure_endpoint(scopes=[Scopes.EMBED_WRITE], endpoint="POST /v1/embed")
     ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     request = _ensure_tenant(request, security, http_request)  # type: ignore[assignment]
     response = service.embed(request)
@@ -397,7 +373,7 @@ async def embed_text(
             "provider": response.metadata.provider,
         },
     )
-    return json_api_response(response, meta=meta)
+    return presenter.success(response, meta=meta)
 
 
 @router.post("/retrieve", status_code=200)
@@ -408,6 +384,7 @@ async def retrieve(
         secure_endpoint(scopes=[Scopes.RETRIEVE_READ], endpoint="POST /v1/retrieve")
     ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     odata = ODataParams.from_request(http_request)
     request = _ensure_tenant(request, security, http_request)  # type: ignore[assignment]
@@ -423,7 +400,7 @@ async def retrieve(
         "stage_timings": result.stage_timings,
         "errors": [error.model_dump(mode="json") for error in result.errors],
     }
-    return json_api_response(result, meta=meta)
+    return presenter.success(result, meta=meta)
 
 
 @router.get("/namespaces", status_code=200)
@@ -433,10 +410,11 @@ async def list_namespaces(
         secure_endpoint(scopes=[Scopes.EMBED_READ], endpoint="GET /v1/namespaces")
     ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     http_request.state.requested_tenant_id = security.tenant_id
     namespaces = service.list_namespaces(tenant_id=security.tenant_id, scope=Scopes.EMBED_READ)
-    return json_api_response(namespaces, meta={"total": len(namespaces)})
+    return presenter.success(namespaces, meta={"total": len(namespaces)})
 
 
 @router.post("/namespaces/{namespace}/validate", status_code=200)
@@ -448,6 +426,7 @@ async def validate_namespace(
         secure_endpoint(scopes=[Scopes.EMBED_READ], endpoint="POST /v1/namespaces/{namespace}/validate")
     ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     request = _ensure_tenant(request, security, http_request)  # type: ignore[assignment]
     result = service.validate_namespace_texts(
@@ -455,7 +434,7 @@ async def validate_namespace(
         namespace=namespace,
         texts=request.texts,
     )
-    return json_api_response(result)
+    return presenter.success(result)
 
 
 @router.post("/evaluate", status_code=200)
@@ -466,6 +445,7 @@ async def evaluate(
         secure_endpoint(scopes=[Scopes.EVALUATE_WRITE], endpoint="POST /v1/evaluate")
     ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     request = _ensure_tenant(request, security, http_request)  # type: ignore[assignment]
     try:
@@ -474,7 +454,7 @@ async def evaluate(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     response = EvaluationResponse.from_result(result)
     meta = {"cache": response.cache, "test_set_version": response.test_set_version}
-    return json_api_response(response, meta=meta)
+    return presenter.success(response, meta=meta)
 
 
 @router.post("/pipelines/query", status_code=200)
@@ -485,6 +465,7 @@ async def query_pipeline(
         secure_endpoint(scopes=[Scopes.RETRIEVE_READ], endpoint="POST /v1/pipelines/query")
     ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     odata = ODataParams.from_request(http_request)
     request = _ensure_tenant(request, security, http_request)  # type: ignore[assignment]
@@ -501,7 +482,7 @@ async def query_pipeline(
         "errors": [error.model_dump(mode="json") for error in result.errors],
         "profile": request.profile,
     }
-    return json_api_response(result, meta=meta)
+    return presenter.success(result, meta=meta)
 
 
 @router.get("/search", status_code=200)
@@ -517,6 +498,7 @@ async def search(
         secure_endpoint(scopes=[Scopes.RETRIEVE_READ], endpoint="GET /v1/search")
     ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     request_model = RetrieveRequest(
         tenant_id=security.tenant_id,
@@ -542,7 +524,7 @@ async def search(
         "intent": result.intent,
         "errors": [error.model_dump(mode="json") for error in result.errors],
     }
-    return json_api_response(result, meta=meta)
+    return presenter.success(result, meta=meta)
 
 
 @router.post("/map/el", status_code=207)
@@ -553,6 +535,7 @@ async def entity_link(
         secure_endpoint(scopes=[Scopes.PROCESS_WRITE], endpoint="POST /v1/map/el")
     ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     request = _ensure_tenant(request, security, http_request)  # type: ignore[assignment]
     results = service.entity_link(request)
@@ -563,7 +546,7 @@ async def entity_link(
         resource="entity_link",
         metadata={"mentions": len(request.mentions)},
     )
-    return json_api_response(results, status_code=207, meta=meta)
+    return presenter.success(results, status_code=207, meta=meta)
 
 
 @router.post("/extract/{kind}", status_code=200)
@@ -576,6 +559,7 @@ async def extract(
         secure_endpoint(scopes=[Scopes.PROCESS_WRITE], endpoint="POST /v1/extract")
     ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     request = _ensure_tenant(request, security, http_request)  # type: ignore[assignment]
     extraction = service.extract(kind, request)
@@ -585,7 +569,7 @@ async def extract(
         resource=f"extract:{kind}",
         metadata={"document_id": request.document_id},
     )
-    return json_api_response(extraction)
+    return presenter.success(extraction)
 
 
 @router.post("/kg/write", status_code=200)
@@ -596,6 +580,7 @@ async def kg_write(
         secure_endpoint(scopes=[Scopes.KG_WRITE], endpoint="POST /v1/kg/write")
     ),
     service: GatewayService = Depends(get_gateway_service),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     request = _ensure_tenant(request, security, http_request)  # type: ignore[assignment]
     result = service.write_kg(request)
@@ -605,7 +590,7 @@ async def kg_write(
         resource="knowledge_graph",
         metadata={"nodes": len(request.nodes), "edges": len(request.edges)},
     )
-    return json_api_response(result)
+    return presenter.success(result)
 
 
 @router.get("/audit/logs", status_code=200)
@@ -614,6 +599,7 @@ async def list_audit_logs(
     security: SecurityContext = Depends(
         secure_endpoint(scopes=[Scopes.AUDIT_READ], endpoint="GET /v1/audit/logs")
     ),
+    presenter: PresenterDep,
 ) -> JSONResponse:
     logs = get_audit_trail().list(tenant_id=security.tenant_id, limit=limit)
     data = [
@@ -627,4 +613,4 @@ async def list_audit_logs(
         }
         for entry in logs
     ]
-    return json_api_response(data, meta={"total": len(data)})
+    return presenter.success(data, meta={"total": len(data)})

--- a/src/Medical_KG_rev/gateway/services.py
+++ b/src/Medical_KG_rev/gateway/services.py
@@ -286,7 +286,7 @@ class GatewayService:
                 adapter_request=adapter_request,
                 payload=payload,
             )
-            result_metadata = {"state": run_result.state}
+            result_metadata = {"state": run_result.state.serialise()}
             if run_result.success:
                 self.ledger.mark_completed(job_id, metadata=result_metadata)
                 self.events.publish(

--- a/src/Medical_KG_rev/orchestration/dagster/runtime.py
+++ b/src/Medical_KG_rev/orchestration/dagster/runtime.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import re
 import time
 from pathlib import Path
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any, Callable, Mapping
 from uuid import uuid4
 
 from dagster import (
@@ -42,7 +42,7 @@ from Medical_KG_rev.orchestration.events import StageEventEmitter
 from Medical_KG_rev.orchestration.kafka import KafkaClient
 from Medical_KG_rev.orchestration.ledger import JobLedger, JobLedgerError
 from Medical_KG_rev.orchestration.openlineage import OpenLineageEmitter
-from Medical_KG_rev.orchestration.stages.contracts import StageContext
+from Medical_KG_rev.orchestration.stages.contracts import PipelineState, StageContext
 from Medical_KG_rev.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -77,14 +77,14 @@ class StageFactory:
 
 @op(
     name="bootstrap",
-    out=Out(dict),
+    out=Out(PipelineState),
     config_schema={
         "context": dict,
         "adapter_request": dict,
         "payload": dict,
     },
 )
-def bootstrap_op(context) -> dict[str, Any]:
+def bootstrap_op(context) -> PipelineState:
     """Initialise the orchestration state for a Dagster run."""
 
     ctx_payload = context.op_config["context"]
@@ -102,90 +102,17 @@ def bootstrap_op(context) -> dict[str, Any]:
     )
     adapter_request = AdapterRequest.model_validate(adapter_payload)
 
-    state = {
-        "context": stage_ctx,
-        "adapter_request": adapter_request,
-        "payload": payload,
-        "results": {},
-        "job_id": stage_ctx.job_id,
-    }
+    state = PipelineState.initialise(
+        context=stage_ctx,
+        adapter_request=adapter_request,
+        payload=payload,
+    )
     logger.debug(
         "dagster.bootstrap.initialised",
         tenant_id=stage_ctx.tenant_id,
         pipeline=stage_ctx.pipeline_name,
     )
     return state
-
-
-def _stage_state_key(stage_type: str) -> str:
-    return {
-        "ingest": "payloads",
-        "parse": "document",
-        "ir-validation": "document",
-        "chunk": "chunks",
-        "embed": "embedding_batch",
-        "index": "index_receipt",
-        "extract": "extraction",
-        "knowledge-graph": "graph_receipt",
-    }.get(stage_type, stage_type)
-
-
-def _apply_stage_output(
-    stage_type: str,
-    stage_name: str,
-    state: dict[str, Any],
-    output: Any,
-) -> dict[str, Any]:
-    if stage_type == "ingest":
-        state["payloads"] = output
-    elif stage_type in {"parse", "ir-validation"}:
-        state["document"] = output
-    elif stage_type == "chunk":
-        state["chunks"] = output
-    elif stage_type == "embed":
-        state["embedding_batch"] = output
-    elif stage_type == "index":
-        state["index_receipt"] = output
-    elif stage_type == "extract":
-        entities, claims = output
-        state["entities"] = entities
-        state["claims"] = claims
-    elif stage_type == "knowledge-graph":
-        state["graph_receipt"] = output
-    else:  # pragma: no cover - guard for future expansion
-        state[_stage_state_key(stage_type)] = output
-    state.setdefault("results", {})[stage_name] = {
-        "type": stage_type,
-        "output": state.get(_stage_state_key(stage_type)),
-    }
-    return state
-
-
-def _infer_output_count(stage_type: str, output: Any) -> int:
-    if output is None:
-        return 0
-    if stage_type in {"ingest", "chunk"} and isinstance(output, Sequence):
-        return len(output)
-    if stage_type in {"parse", "ir-validation"}:
-        return 1
-    if stage_type == "embed" and hasattr(output, "vectors"):
-        vectors = getattr(output, "vectors")
-        if isinstance(vectors, Sequence):
-            return len(vectors)
-    if stage_type == "index" and hasattr(output, "chunks_indexed"):
-        indexed = getattr(output, "chunks_indexed")
-        if isinstance(indexed, int):
-            return indexed
-    if stage_type == "extract" and isinstance(output, tuple) and len(output) == 2:
-        entities, claims = output
-        entity_count = len(entities) if isinstance(entities, Sequence) else 0
-        claim_count = len(claims) if isinstance(claims, Sequence) else 0
-        return entity_count + claim_count
-    if stage_type == "knowledge-graph" and hasattr(output, "nodes_written"):
-        nodes = getattr(output, "nodes_written", 0)
-        if isinstance(nodes, int):
-            return nodes
-    return 1
 
 
 def _make_stage_op(
@@ -198,8 +125,8 @@ def _make_stage_op(
 
     @op(
         name=stage_name,
-        ins={"state": In(dict)},
-        out=Out(dict),
+        ins={"state": In(PipelineState)},
+        out=Out(PipelineState),
         required_resource_keys={
             "stage_factory",
             "resilience_policies",
@@ -207,7 +134,7 @@ def _make_stage_op(
             "event_emitter",
         },
     )
-    def _stage_op(context, state: dict[str, Any]) -> dict[str, Any]:
+    def _stage_op(context, state: PipelineState) -> PipelineState:
         stage = context.resources.stage_factory.resolve(topology.name, stage_definition)
         policy_loader: ResiliencePolicyLoader = context.resources.resilience_policies
 
@@ -220,7 +147,7 @@ def _make_stage_op(
         }
 
         def _on_retry(retry_state: Any) -> None:
-            job_identifier = state.get("job_id")
+            job_identifier = state.job_id
             if job_identifier:
                 ledger.increment_retry(job_identifier, stage_name)
             sleep_seconds = getattr(getattr(retry_state, "next_action", None), "sleep", 0.0) or 0.0
@@ -228,7 +155,7 @@ def _make_stage_op(
             error = getattr(getattr(retry_state, "outcome", None), "exception", lambda: None)()
             reason = str(error) if error else "retry"
             emitter.emit_retrying(
-                state["context"],
+                state.context,
                 stage_name,
                 attempt=attempt_number,
                 backoff_ms=int(sleep_seconds * 1000),
@@ -252,57 +179,47 @@ def _make_stage_op(
 
         wrapped = policy_loader.apply(policy_name, stage_name, execute, hooks=hooks)
 
-        stage_ctx: StageContext = state["context"]
-        job_id = stage_ctx.job_id or state.get("job_id")
+        stage_ctx: StageContext = state.context
+        job_id = state.job_id or stage_ctx.job_id
 
         initial_attempt = 1
         if job_id:
             entry = ledger.mark_stage_started(job_id, stage_name)
             initial_attempt = entry.retry_count_per_stage.get(stage_name, 0) + 1
+            state.job_id = entry.job_id
+            stage_ctx.job_id = entry.job_id
         emitter.emit_started(stage_ctx, stage_name, attempt=initial_attempt)
 
         start_time = time.perf_counter()
 
         try:
-            if stage_type == "ingest":
-                adapter_request: AdapterRequest = state["adapter_request"]
-                result = wrapped(stage_ctx, adapter_request)
-            elif stage_type in {"parse", "ir-validation"}:
-                payloads = state.get("payloads", [])
-                result = wrapped(stage_ctx, payloads)
-            elif stage_type == "chunk":
-                document = state.get("document")
-                result = wrapped(stage_ctx, document)
-            elif stage_type == "embed":
-                chunks = state.get("chunks", [])
-                result = wrapped(stage_ctx, chunks)
-            elif stage_type == "index":
-                batch = state.get("embedding_batch")
-                result = wrapped(stage_ctx, batch)
-            elif stage_type == "extract":
-                document = state.get("document")
-                result = wrapped(stage_ctx, document)
-            elif stage_type == "knowledge-graph":
-                entities = state.get("entities", [])
-                claims = state.get("claims", [])
-                result = wrapped(stage_ctx, entities, claims)
-            else:  # pragma: no cover - guard for future expansion
-                upstream = state.get(_stage_state_key(stage_type))
-                result = wrapped(stage_ctx, upstream)
+            state.ensure_ready_for(stage_type)
+            result = wrapped(stage_ctx, state)
         except Exception as exc:
             attempts = execution_state.get("attempts") or 1
             emitter.emit_failed(stage_ctx, stage_name, attempt=attempts, error=str(exc))
             if job_id:
                 ledger.mark_failed(job_id, stage=stage_name, reason=str(exc))
+            state.record_stage_metrics(
+                stage_name,
+                stage_type=stage_type,
+                attempts=attempts,
+                error=str(exc),
+            )
             raise
 
-        updated = dict(state)
-        _apply_stage_output(stage_type, stage_name, updated, result)
-        output = updated.get(_stage_state_key(stage_type))
+        state.apply_stage_output(stage_type, stage_name, result)
         attempts = execution_state.get("attempts") or 1
         duration_seconds = execution_state.get("duration") or (time.perf_counter() - start_time)
         duration_ms = int(duration_seconds * 1000)
-        output_count = _infer_output_count(stage_type, output)
+        output_count = state.infer_output_count(stage_type, result)
+        state.record_stage_metrics(
+            stage_name,
+            stage_type=stage_type,
+            attempts=attempts,
+            duration_ms=duration_ms,
+            output_count=output_count,
+        )
 
         if job_id:
             ledger.update_metadata(
@@ -330,7 +247,7 @@ def _make_stage_op(
             duration_ms=duration_ms,
             output_count=output_count,
         )
-        return updated
+        return state
 
     return _stage_op
 
@@ -423,7 +340,7 @@ class DagsterRunResult:
 
     pipeline: str
     success: bool
-    state: dict[str, Any]
+    state: PipelineState
     dagster_result: ExecuteInProcessResult
 
 

--- a/src/Medical_KG_rev/orchestration/stages/contracts.py
+++ b/src/Medical_KG_rev/orchestration/stages/contracts.py
@@ -10,7 +10,7 @@ remains framework agnostic.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Mapping, Protocol, Sequence, runtime_checkable
 
 from Medical_KG_rev.adapters.plugins.models import AdapterRequest
 from Medical_KG_rev.chunking.models import Chunk
@@ -86,54 +86,379 @@ class StageContext:
             pipeline_version=self.pipeline_version,
         )
 
+    def to_dict(self) -> dict[str, Any]:
+        """Return a serialisable representation of the context."""
+
+        return {
+            "tenant_id": self.tenant_id,
+            "job_id": self.job_id,
+            "doc_id": self.doc_id,
+            "correlation_id": self.correlation_id,
+            "metadata": dict(self.metadata),
+            "pipeline_name": self.pipeline_name,
+            "pipeline_version": self.pipeline_version,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> StageContext:
+        """Rehydrate a context from a mapping payload."""
+
+        return cls(
+            tenant_id=str(payload.get("tenant_id")),
+            job_id=payload.get("job_id"),
+            doc_id=payload.get("doc_id"),
+            correlation_id=payload.get("correlation_id"),
+            metadata=dict(payload.get("metadata", {})),
+            pipeline_name=payload.get("pipeline_name"),
+            pipeline_version=payload.get("pipeline_version"),
+        )
+
+
+@dataclass(slots=True)
+class StageResultSnapshot:
+    """Aggregated metadata describing a stage execution."""
+
+    stage: str
+    stage_type: str
+    attempts: int | None = None
+    duration_ms: int | None = None
+    output_count: int | None = None
+    error: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "stage": self.stage,
+            "stage_type": self.stage_type,
+            "attempts": self.attempts,
+            "duration_ms": self.duration_ms,
+            "output_count": self.output_count,
+            "error": self.error,
+        }
+
+
+@dataclass(slots=True)
+class PipelineState:
+    """Strongly-typed representation of the orchestration pipeline state."""
+
+    context: StageContext
+    adapter_request: AdapterRequest
+    payload: dict[str, Any] = field(default_factory=dict)
+    payloads: tuple[RawPayload, ...] = ()
+    document: Document | None = None
+    chunks: tuple[Chunk, ...] = ()
+    embedding_batch: EmbeddingBatch | None = None
+    entities: tuple[Entity, ...] = ()
+    claims: tuple[Claim, ...] = ()
+    index_receipt: IndexReceipt | None = None
+    graph_receipt: GraphWriteReceipt | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    stage_results: dict[str, StageResultSnapshot] = field(default_factory=dict)
+    schema_version: str = "v1"
+    job_id: str | None = None
+
+    @classmethod
+    def initialise(
+        cls,
+        *,
+        context: StageContext,
+        adapter_request: AdapterRequest,
+        payload: Mapping[str, Any] | None = None,
+    ) -> PipelineState:
+        """Factory helper used during bootstrap to create a state instance."""
+
+        return cls(
+            context=context,
+            adapter_request=adapter_request,
+            payload=dict(payload or {}),
+            job_id=context.job_id,
+        )
+
+    # ------------------------------------------------------------------
+    # Accessors
+    # ------------------------------------------------------------------
+    def get_payloads(self) -> tuple[RawPayload, ...]:
+        return self.payloads
+
+    def set_payloads(self, payloads: Sequence[RawPayload]) -> None:
+        self.payloads = tuple(payloads)
+
+    def require_payloads(self) -> tuple[RawPayload, ...]:
+        if not self.payloads:
+            raise ValueError("PipelineState requires payloads before parse stage execution")
+        return self.payloads
+
+    def has_document(self) -> bool:
+        return self.document is not None
+
+    def set_document(self, document: Document) -> None:
+        self.document = document
+
+    def require_document(self) -> Document:
+        if self.document is None:
+            raise ValueError("PipelineState does not contain a parsed document")
+        return self.document
+
+    def has_chunks(self) -> bool:
+        return bool(self.chunks)
+
+    def set_chunks(self, chunks: Sequence[Chunk]) -> None:
+        self.chunks = tuple(chunks)
+
+    def require_chunks(self) -> tuple[Chunk, ...]:
+        if not self.chunks:
+            raise ValueError("PipelineState does not contain document chunks")
+        return self.chunks
+
+    def has_embeddings(self) -> bool:
+        return self.embedding_batch is not None and bool(self.embedding_batch.vectors)
+
+    def set_embedding_batch(self, batch: EmbeddingBatch) -> None:
+        self.embedding_batch = batch
+
+    def require_embedding_batch(self) -> EmbeddingBatch:
+        if self.embedding_batch is None:
+            raise ValueError("PipelineState does not contain embedding results")
+        return self.embedding_batch
+
+    def set_entities_and_claims(
+        self,
+        entities: Sequence[Entity],
+        claims: Sequence[Claim],
+    ) -> None:
+        self.entities = tuple(entities)
+        self.claims = tuple(claims)
+
+    def has_entities(self) -> bool:
+        return bool(self.entities)
+
+    def has_claims(self) -> bool:
+        return bool(self.claims)
+
+    def require_entities(self) -> tuple[Entity, ...]:
+        if not self.entities:
+            raise ValueError("PipelineState does not contain extracted entities")
+        return self.entities
+
+    def require_claims(self) -> tuple[Claim, ...]:
+        if not self.claims:
+            raise ValueError("PipelineState does not contain extracted claims")
+        return self.claims
+
+    def set_index_receipt(self, receipt: IndexReceipt) -> None:
+        self.index_receipt = receipt
+
+    def set_graph_receipt(self, receipt: GraphWriteReceipt) -> None:
+        self.graph_receipt = receipt
+
+    def ensure_ready_for(self, stage_type: str) -> None:
+        """Validate preconditions required by the requested stage type."""
+
+        if stage_type in {"parse", "ir-validation"}:
+            self.require_payloads()
+        elif stage_type == "chunk":
+            self.require_document()
+        elif stage_type == "embed":
+            self.require_chunks()
+        elif stage_type == "index":
+            self.require_embedding_batch()
+        elif stage_type == "extract":
+            self.require_document()
+        elif stage_type == "knowledge-graph":
+            # Extraction stages may legitimately produce empty collections but the
+            # state must contain the tuple marker.
+            if self.entities is None or self.claims is None:
+                raise ValueError("PipelineState requires extraction outputs before KG stage")
+
+    # ------------------------------------------------------------------
+    # Stage bookkeeping
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _stage_state_key(stage_type: str) -> str:
+        return {
+            "ingest": "payloads",
+            "parse": "document",
+            "ir-validation": "document",
+            "chunk": "chunks",
+            "embed": "embedding_batch",
+            "index": "index_receipt",
+            "extract": "extraction",
+            "knowledge-graph": "graph_receipt",
+        }.get(stage_type, stage_type)
+
+    def apply_stage_output(self, stage_type: str, stage_name: str, output: Any) -> None:
+        """Persist a stage output onto the typed state structure."""
+
+        key = self._stage_state_key(stage_type)
+        if stage_type == "ingest":
+            values = output or []
+            if not isinstance(values, Sequence):
+                raise TypeError("Ingest stage must return a sequence of payloads")
+            self.set_payloads(values)
+        elif stage_type in {"parse", "ir-validation"}:
+            if not isinstance(output, Document):
+                raise TypeError("Parse stages must return a Document instance")
+            self.set_document(output)
+        elif stage_type == "chunk":
+            if not isinstance(output, Sequence):
+                raise TypeError("Chunk stage must return a sequence of Chunk instances")
+            self.set_chunks(output)
+        elif stage_type == "embed":
+            if not isinstance(output, EmbeddingBatch):
+                raise TypeError("Embed stage must return an EmbeddingBatch")
+            self.set_embedding_batch(output)
+        elif stage_type == "index":
+            if not isinstance(output, IndexReceipt):
+                raise TypeError("Index stage must return an IndexReceipt")
+            self.set_index_receipt(output)
+        elif stage_type == "extract":
+            if (
+                not isinstance(output, tuple)
+                or len(output) != 2
+                or not isinstance(output[0], Sequence)
+                or not isinstance(output[1], Sequence)
+            ):
+                raise TypeError("Extract stage must return a tuple of entity and claim sequences")
+            entities, claims = output
+            self.set_entities_and_claims(entities, claims)
+        elif stage_type == "knowledge-graph":
+            if not isinstance(output, GraphWriteReceipt):
+                raise TypeError("Knowledge graph stage must return a GraphWriteReceipt")
+            self.set_graph_receipt(output)
+        else:
+            self.metadata[key] = output
+
+        self.stage_results[stage_name] = StageResultSnapshot(stage=stage_name, stage_type=stage_type)
+
+    def infer_output_count(self, stage_type: str, output: Any) -> int:
+        if output is None:
+            return 0
+        if stage_type in {"ingest", "chunk"} and isinstance(output, Sequence):
+            return len(output)
+        if stage_type in {"parse", "ir-validation"}:
+            return 1
+        if stage_type == "embed" and isinstance(output, EmbeddingBatch):
+            return len(output.vectors)
+        if stage_type == "index" and isinstance(output, IndexReceipt):
+            return output.chunks_indexed
+        if stage_type == "extract" and isinstance(output, tuple) and len(output) == 2:
+            entities, claims = output
+            entity_count = len(entities) if isinstance(entities, Sequence) else 0
+            claim_count = len(claims) if isinstance(claims, Sequence) else 0
+            return entity_count + claim_count
+        if stage_type == "knowledge-graph" and isinstance(output, GraphWriteReceipt):
+            return output.nodes_written
+        return 1
+
+    def record_stage_metrics(
+        self,
+        stage_name: str,
+        *,
+        stage_type: str | None = None,
+        attempts: int | None = None,
+        duration_ms: int | None = None,
+        output_count: int | None = None,
+        error: str | None = None,
+    ) -> None:
+        snapshot = self.stage_results.setdefault(
+            stage_name,
+            StageResultSnapshot(stage=stage_name, stage_type="unknown"),
+        )
+        if stage_type:
+            snapshot.stage_type = stage_type
+        snapshot.attempts = attempts
+        snapshot.duration_ms = duration_ms
+        snapshot.output_count = output_count
+        snapshot.error = error
+
+    # ------------------------------------------------------------------
+    # Serialisation helpers
+    # ------------------------------------------------------------------
+    def serialise(self) -> dict[str, Any]:
+        """Return a metadata snapshot suitable for logging or Kafka payloads."""
+
+        return {
+            "version": self.schema_version,
+            "job_id": self.job_id,
+            "context": self.context.to_dict(),
+            "adapter_request": self.adapter_request.model_dump(),
+            "payload": dict(self.payload),
+            "payload_count": len(self.payloads),
+            "document_id": getattr(self.document, "id", None),
+            "chunk_count": len(self.chunks),
+            "embedding_count": len(self.embedding_batch.vectors)
+            if self.embedding_batch
+            else 0,
+            "entity_count": len(self.entities),
+            "claim_count": len(self.claims),
+            "index_receipt": self.index_receipt.metadata if self.index_receipt else None,
+            "graph_receipt": self.graph_receipt.metadata if self.graph_receipt else None,
+            "stage_results": {name: result.as_dict() for name, result in self.stage_results.items()},
+        }
+
+    @classmethod
+    def recover(
+        cls,
+        payload: Mapping[str, Any],
+        *,
+        context: StageContext,
+        adapter_request: AdapterRequest,
+    ) -> PipelineState:
+        """Best-effort recovery for pipeline state snapshots."""
+
+        state = cls.initialise(context=context, adapter_request=adapter_request, payload=payload.get("payload"))
+        state.schema_version = str(payload.get("version", "v1"))
+        state.job_id = payload.get("job_id") or context.job_id
+        state.metadata.update(dict(payload.get("metadata", {})))
+        return state
+
 
 @runtime_checkable
 class IngestStage(Protocol):
     """Fetch raw payloads from the configured adapter."""
 
-    def execute(self, ctx: StageContext, request: AdapterRequest) -> list[RawPayload]: ...
+    def execute(self, ctx: StageContext, state: PipelineState) -> list[RawPayload]: ...
 
 
 @runtime_checkable
 class ParseStage(Protocol):
     """Transform raw payloads into the canonical IR document."""
 
-    def execute(self, ctx: StageContext, payloads: list[RawPayload]) -> Document: ...
+    def execute(self, ctx: StageContext, state: PipelineState) -> Document: ...
 
 
 @runtime_checkable
 class ChunkStage(Protocol):
     """Split an IR document into retrieval-ready chunks."""
 
-    def execute(self, ctx: StageContext, document: Document) -> list[Chunk]: ...
+    def execute(self, ctx: StageContext, state: PipelineState) -> list[Chunk]: ...
 
 
 @runtime_checkable
 class EmbedStage(Protocol):
     """Generate dense and/or sparse embeddings for a batch of chunks."""
 
-    def execute(self, ctx: StageContext, chunks: list[Chunk]) -> EmbeddingBatch: ...
+    def execute(self, ctx: StageContext, state: PipelineState) -> EmbeddingBatch: ...
 
 
 @runtime_checkable
 class IndexStage(Protocol):
     """Persist embeddings into the vector and lexical indices."""
 
-    def execute(self, ctx: StageContext, batch: EmbeddingBatch) -> IndexReceipt: ...
+    def execute(self, ctx: StageContext, state: PipelineState) -> IndexReceipt: ...
 
 
 @runtime_checkable
 class ExtractStage(Protocol):
     """Run extraction models over the IR document."""
 
-    def execute(self, ctx: StageContext, document: Document) -> tuple[list[Entity], list[Claim]]: ...
+    def execute(self, ctx: StageContext, state: PipelineState) -> tuple[list[Entity], list[Claim]]: ...
 
 
 @runtime_checkable
 class KGStage(Protocol):
     """Write extracted entities and claims into the knowledge graph."""
 
-    def execute(self, ctx: StageContext, entities: list[Entity], claims: list[Claim]) -> GraphWriteReceipt: ...
+    def execute(self, ctx: StageContext, state: PipelineState) -> GraphWriteReceipt: ...
 
 
 __all__ = [
@@ -146,7 +471,9 @@ __all__ = [
     "IngestStage",
     "IndexReceipt",
     "IndexStage",
+    "PipelineState",
     "KGStage",
+    "StageResultSnapshot",
     "ParseStage",
     "RawPayload",
     "StageContext",

--- a/tests/orchestration/test_dagster_sensors.py
+++ b/tests/orchestration/test_dagster_sensors.py
@@ -58,3 +58,7 @@ def test_pdf_ir_sensor_emits_run_request() -> None:
     assert adapter_config["parameters"]["dataset"] == "pmc"
 
     assert request.tags["medical_kg.resume_stage"] == "chunk"
+    assert request.tags["medical_kg.pipeline"] == "pdf-two-phase"
+
+    metadata_ctx = ctx_config["metadata"]
+    assert metadata_ctx["correlation_id"] == "corr-sensor"

--- a/tests/orchestration/test_pipeline_state.py
+++ b/tests/orchestration/test_pipeline_state.py
@@ -1,0 +1,100 @@
+import pytest
+
+from Medical_KG_rev.adapters.plugins.models import AdapterDomain, AdapterRequest
+from Medical_KG_rev.chunking.models import Chunk
+from Medical_KG_rev.models.ir import Block, BlockType, Document, Section
+from Medical_KG_rev.orchestration.stages.contracts import (
+    EmbeddingBatch,
+    EmbeddingVector,
+    GraphWriteReceipt,
+    IndexReceipt,
+    PipelineState,
+    StageContext,
+)
+
+
+def _build_document() -> Document:
+    block = Block(id="b1", type=BlockType.PARAGRAPH, text="Hello world")
+    section = Section(id="s1", title="Section", blocks=(block,))
+    return Document(id="doc-1", source="test", sections=(section,), metadata={})
+
+
+def _sample_state() -> PipelineState:
+    ctx = StageContext(tenant_id="tenant", correlation_id="corr", pipeline_name="unit")
+    request = AdapterRequest(
+        tenant_id="tenant",
+        correlation_id="corr",
+        domain=AdapterDomain.BIOMEDICAL,
+        parameters={},
+    )
+    return PipelineState.initialise(context=ctx, adapter_request=request, payload={"foo": "bar"})
+
+
+def test_pipeline_state_stage_flow_serialises() -> None:
+    state = _sample_state()
+    with pytest.raises(ValueError):
+        state.ensure_ready_for("parse")
+
+    payloads = [{"id": "p1"}]
+    state.apply_stage_output("ingest", "ingest", payloads)
+    assert state.require_payloads() == tuple(payloads)
+
+    document = _build_document()
+    state.apply_stage_output("parse", "parse", document)
+    assert state.has_document()
+    state.ensure_ready_for("chunk")
+
+    chunk = Chunk(
+        chunk_id="c1",
+        doc_id=document.id,
+        tenant_id="tenant",
+        body="chunk text",
+        title_path=("Section",),
+        section="s1",
+        start_char=0,
+        end_char=10,
+        granularity="paragraph",
+        chunker="stub",
+        chunker_version="1",
+    )
+    state.apply_stage_output("chunk", "chunk", [chunk])
+    assert state.require_chunks()[0].chunk_id == "c1"
+
+    batch = EmbeddingBatch(
+        vectors=(
+            EmbeddingVector(id="c1", values=(0.1, 0.2), metadata={"chunk_id": "c1"}),
+        ),
+        model="stub",
+        tenant_id="tenant",
+    )
+    state.apply_stage_output("embed", "embed", batch)
+    assert state.has_embeddings()
+
+    receipt = IndexReceipt(chunks_indexed=1, opensearch_ok=True, faiss_ok=True)
+    state.apply_stage_output("index", "index", receipt)
+    state.record_stage_metrics("index", stage_type="index", output_count=1)
+    assert state.index_receipt == receipt
+
+    state.apply_stage_output("extract", "extract", ([], []))
+    state.apply_stage_output(
+        "knowledge-graph",
+        "kg",
+        GraphWriteReceipt(nodes_written=1, edges_written=0, correlation_id="corr", metadata={}),
+    )
+
+    snapshot = state.serialise()
+    assert snapshot["payload_count"] == 1
+    assert snapshot["chunk_count"] == 1
+    assert snapshot["embedding_count"] == 1
+    assert snapshot["stage_results"]["index"]["output_count"] == 1
+
+
+def test_pipeline_state_recover_handles_partial_payload() -> None:
+    state = _sample_state()
+    recovered = PipelineState.recover(
+        {"version": "v2", "metadata": {"note": "ok"}},
+        context=state.context,
+        adapter_request=state.adapter_request,
+    )
+    assert recovered.schema_version == "v2"
+    assert recovered.metadata["note"] == "ok"

--- a/tests/orchestration/test_stage_contracts.py
+++ b/tests/orchestration/test_stage_contracts.py
@@ -16,6 +16,7 @@ from Medical_KG_rev.orchestration.stages.contracts import (
     IndexStage,
     KGStage,
     ParseStage,
+    PipelineState,
     StageContext,
 )
 
@@ -62,49 +63,60 @@ def _definition(stage_type: str, name: str, config: dict | None = None) -> Stage
 def test_default_stage_factory_complies_with_protocols(stage_context, adapter_request):
     manager = StubPluginManager()
     registry = build_default_stage_factory(manager)
+    state = PipelineState.initialise(context=stage_context, adapter_request=adapter_request)
 
     ingest = registry["ingest"](
         _definition("ingest", "ingest", {"adapter": "clinical-trials", "strict": False})
     )
     assert isinstance(ingest, IngestStage)
-    payloads = ingest.execute(stage_context, adapter_request)
+    payloads = ingest.execute(stage_context, state)
     assert payloads and isinstance(payloads[0], dict)
+    state.apply_stage_output("ingest", "ingest", payloads)
 
     parse = registry["parse"](_definition("parse", "parse"))
     assert isinstance(parse, ParseStage)
-    document = parse.execute(stage_context, payloads)
+    document = parse.execute(stage_context, state)
+    state.apply_stage_output("parse", "parse", document)
 
     validator = registry["ir-validation"](_definition("ir-validation", "ir_validation"))
     assert isinstance(validator, ParseStage)
-    validated = validator.execute(stage_context, document)
+    validated = validator.execute(stage_context, state)
     assert validated is document
+    state.apply_stage_output("ir-validation", "ir_validation", validated)
 
     chunker = registry["chunk"](_definition("chunk", "chunk"))
     assert isinstance(chunker, ChunkStage)
-    chunks = chunker.execute(stage_context, document)
+    chunks = chunker.execute(stage_context, state)
     assert chunks and chunks[0].doc_id == document.id
+    state.apply_stage_output("chunk", "chunk", chunks)
 
     embedder = registry["embed"](_definition("embed", "embed"))
     assert isinstance(embedder, EmbedStage)
-    batch = embedder.execute(stage_context, chunks)
+    batch = embedder.execute(stage_context, state)
     assert isinstance(batch, EmbeddingBatch)
     assert batch.vectors
+    state.apply_stage_output("embed", "embed", batch)
 
     indexer = registry["index"](_definition("index", "index"))
     assert isinstance(indexer, IndexStage)
-    receipt = indexer.execute(stage_context, batch)
+    receipt = indexer.execute(stage_context, state)
     assert isinstance(receipt, IndexReceipt)
     assert receipt.chunks_indexed == len(batch.vectors)
+    state.apply_stage_output("index", "index", receipt)
 
     extractor = registry["extract"](_definition("extract", "extract"))
     assert isinstance(extractor, ExtractStage)
-    entities, claims = extractor.execute(stage_context, document)
+    entities, claims = extractor.execute(stage_context, state)
     assert entities == [] and claims == []
+    state.apply_stage_output("extract", "extract", (entities, claims))
 
     kg_stage = registry["knowledge-graph"](_definition("knowledge-graph", "kg"))
     assert isinstance(kg_stage, KGStage)
-    graph_receipt = kg_stage.execute(stage_context, entities, claims)
+    graph_receipt = kg_stage.execute(stage_context, state)
     assert isinstance(graph_receipt, GraphWriteReceipt)
     assert graph_receipt.nodes_written == 0
+    state.apply_stage_output("knowledge-graph", "kg", graph_receipt)
 
     assert manager.invocations and manager.invocations[0][0] == "clinical-trials"
+    assert state.has_document() and state.has_embeddings()
+    assert state.serialise()["chunk_count"] == len(chunks)


### PR DESCRIPTION
## Summary
- replace the Dagster runtime dictionary state with a typed `PipelineState`, update stage contracts, and add validation helpers
- add a JSON:API presentation layer with reusable presenter and OData parser, refactoring REST routes to inject the presenter
- extend gateway and orchestration tests for PDF ingestion metadata, sensor tags, and new pipeline state behaviour

## Testing
- `pytest tests/orchestration/test_stage_contracts.py tests/orchestration/test_pipeline_state.py tests/gateway/test_gateway_pdf_ingest.py tests/orchestration/test_dagster_sensors.py` *(fails: missing dagster/pydantic runtime dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e6705ac468832f9e0e9c2ad0f99a5b